### PR TITLE
Tests fix

### DIFF
--- a/src/smash-league-interactions.js
+++ b/src/smash-league-interactions.js
@@ -118,7 +118,7 @@ const getLookupChallengersResponseFromWitEntities = (user, witEntities) => {
                 })
             }
 
-            const playersArray = SmashLeague.getPlayersThatCanBeChallenged(playerPlace, playerScore.range, Ranking.ranking)
+            const playersArray = SmashLeague.getPlayersThatCanBeChallenged(playerPlace, playerScore.range, Ranking, userWhoWantstoKnow)
             if (value.includes('_all')) {
                 return results.push({
                     ok: true,

--- a/src/smash-league.js
+++ b/src/smash-league.js
@@ -1,5 +1,10 @@
 'use strict'
-const { logIgnoredMatch, getPlayerAlias } = require('./utils')
+const {
+    getPlayerAlias,
+    logIgnoredMatch,
+    removeAlreadyChallengedPlayers,
+    removeEmptyArray
+} = require('./utils')
 
 const getRankingPlaceByPlayerId = (userId, ranking) => {
     for (let idx = 0; idx < ranking.length; idx++) {
@@ -266,12 +271,15 @@ const commitInProgress = rankingObj => {
     return result
 }
 
-const getPlayersThatCanBeChallenged = (playerPlace, playerRange, rankingTable) => {
+const getPlayersThatCanBeChallenged = (playerPlace, playerRange, completeRanking, playerId) => {
+    const { in_progress, ranking } = completeRanking
     let index = playerPlace - playerRange - 1
+
     if (index < 0) {
         index = 0
     }
-    return rankingTable.slice(index, index + playerRange)
+
+    return removeEmptyArray(removeAlreadyChallengedPlayers(ranking.slice(index, index + playerRange), playerId, in_progress))
 }
 
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -82,6 +82,23 @@ const removesBotTagFromString = msg => {
     return msg.replace(new RegExp(`<@${Config.bot_id}>`, 'gm'), '').trim()
 }
 
+const removeAlreadyChallengedPlayers = (players, playerId, in_progress) => {
+    const { scoreboard } = in_progress
+    const { completed_challenges } = scoreboard[playerId]
+
+    return players.map(rankPlayers => rankPlayers.filter(id => {
+        let canBeChallenged = null;
+
+        for (const i in completed_challenges) {
+            canBeChallenged = (completed_challenges[i].player1 === id || completed_challenges[i].player2 === id) ? false : true
+        }
+
+        return canBeChallenged
+    }))
+}
+
+const removeEmptyArray = array => array.filter(i => (i.length === 0) ? false : true)
+
 module.exports = {
     GetDateObjFromEpochTS,
     GetEpochUnixFromDate,
@@ -93,4 +110,6 @@ module.exports = {
     templateString,
     getRandomMessageById,
     removesBotTagFromString,
+    removeAlreadyChallengedPlayers,
+    removeEmptyArray,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -84,17 +84,20 @@ const removesBotTagFromString = msg => {
 
 const removeAlreadyChallengedPlayers = (players, playerId, in_progress) => {
     const { scoreboard } = in_progress
-    const { completed_challenges } = scoreboard[playerId]
+    const { completed_challenges = [] } = scoreboard[playerId] || {}
 
-    return players.map(rankPlayers => rankPlayers.filter(id => {
-        let canBeChallenged = null;
-
-        for (const i in completed_challenges) {
-            canBeChallenged = (completed_challenges[i].player1 === id || completed_challenges[i].player2 === id) ? false : true
-        }
-
-        return canBeChallenged
-    }))
+    return players.map(
+        rankPlayers => rankPlayers.filter(
+            id => {
+                for (const challenge of completed_challenges) {
+                    if ( challenge.players.includes(id) && challenge.winner === playerId ) {
+                        return false
+                    }
+                }
+                return true
+            }
+        )
+    )
 }
 
 const removeEmptyArray = array => array.filter(i => (i.length === 0) ? false : true)


### PR DESCRIPTION
## What does this do?
Fixes 2 bugs on `removeAlreadyChallengedPlayers` at `utils.js`:

1. New players won't be on the scoreboard therefore destructuring `completed_challenges` will throw an error when returning _undefined_. 
1. The player can't challenge another player only if that player already won against the other player. There was missing a validation for that. Before it was just checking if they played, but was never considered the winner of the match.

## How can this change be undone in case of failure?

1. Notify the administrators
2. Request a revert of the PR


ping @Xotl
