### PR TITLE
Fixing tests

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -84,17 +84,20 @@ const removesBotTagFromString = msg => {
 
 const removeAlreadyChallengedPlayers = (players, playerId, in_progress) => {
     const { scoreboard } = in_progress
-    const { completed_challenges } = scoreboard[playerId]
+    const { completed_challenges = [] } = scoreboard[playerId] || {}
 
-    return players.map(rankPlayers => rankPlayers.filter(id => {
-        let canBeChallenged = null;
-
-        for (const i in completed_challenges) {
-            canBeChallenged = (completed_challenges[i].player1 === id || completed_challenges[i].player2 === id) ? false : true
-        }
-
-        return canBeChallenged
-    }))
+    return players.map(
+        rankPlayers => rankPlayers.filter(
+            id => {
+                for (const challenge of completed_challenges) {
+                    if ( challenge.players.includes(id) && challenge.winner === playerId ) {
+                        return false
+                    }
+                }
+                return true
+            }
+        )
+    )
 }
 
 const removeEmptyArray = array => array.filter(i => (i.length === 0) ? false : true)


### PR DESCRIPTION
## What does this do?
Fixes 2 bugs on `removeAlreadyChallengedPlayers` at `utils.js`:

1. New players won't be on the scoreboard therefore destructuring `completed_challenges` will throw an error when returning _undefined_. 
1. A player can't challenge another player only if that player already won against the other player. There was missing a validation for that. Before it was just checking if they played, but was never considered the winner of the match.

## How can this change be undone in case of failure?

1. Notify the administrators
2. Request a revert of the PR


ping @Xotl


*Note:* This needs to be merged first before merging #59 