### PR TITLE
Remove players that have already been challenged (#52)

### DIFF
--- a/src/smash-league-interactions.js
+++ b/src/smash-league-interactions.js
@@ -118,7 +118,7 @@ const getLookupChallengersResponseFromWitEntities = (user, witEntities) => {
                 })
             }
 
-            const playersArray = SmashLeague.getPlayersThatCanBeChallenged(playerPlace, playerScore.range, Ranking.ranking)
+            const playersArray = SmashLeague.getPlayersThatCanBeChallenged(playerPlace, playerScore.range, Ranking, userWhoWantstoKnow)
             if (value.includes('_all')) {
                 return results.push({
                     ok: true,

--- a/src/smash-league.js
+++ b/src/smash-league.js
@@ -1,5 +1,10 @@
 'use strict'
-const { logIgnoredMatch, getPlayerAlias } = require('./utils')
+const {
+    getPlayerAlias,
+    logIgnoredMatch,
+    removeAlreadyChallengedPlayers,
+    removeEmptyArray
+} = require('./utils')
 
 const getRankingPlaceByPlayerId = (userId, ranking) => {
     for (let idx = 0; idx < ranking.length; idx++) {
@@ -266,12 +271,15 @@ const commitInProgress = rankingObj => {
     return result
 }
 
-const getPlayersThatCanBeChallenged = (playerPlace, playerRange, rankingTable) => {
+const getPlayersThatCanBeChallenged = (playerPlace, playerRange, completeRanking, playerId) => {
+    const { in_progress, ranking } = completeRanking
     let index = playerPlace - playerRange - 1
+
     if (index < 0) {
         index = 0
     }
-    return rankingTable.slice(index, index + playerRange)
+
+    return removeEmptyArray(removeAlreadyChallengedPlayers(ranking.slice(index, index + playerRange), playerId, in_progress))
 }
 
 

--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -2,7 +2,8 @@
 
 const {
     GetEpochUnixFromDate, GetDateObjFromEpochTS, setIgnoredActivityLogObject, logIgnoredActivity,
-    logIgnoredMatch, showInConsoleIgnoredActivities
+    logIgnoredMatch, showInConsoleIgnoredActivities, removeAlreadyChallengedPlayers, 
+    removeEmptyArray
 } = require('../utils')
 
 
@@ -53,9 +54,66 @@ describe('Utils', () => {
 
         showInConsoleIgnoredActivities(tmpActivities)
         expect( logFnSpy ).toHaveBeenCalledTimes(6)
-        expect( logFnSpy ).toHaveBeenNthCalledWith(3, 'A total of 1 test activities ignored.');
-        expect( logFnSpy ).toHaveBeenNthCalledWith(6, 'A total of 2 match activities ignored.');
+        expect( logFnSpy ).toHaveBeenNthCalledWith(3, 'A total of 1 test activities ignored.')
+        expect( logFnSpy ).toHaveBeenNthCalledWith(6, 'A total of 2 match activities ignored.')
 
         logFnSpy.mockRestore()
     })
+
+    test('removeAlreadyChallengedPlayers', () => {
+
+        expect(
+            removeAlreadyChallengedPlayers(
+                [ ["Xotl"], ["Paco", "José"], ["Lee"] ],
+                "Sammy",
+                {
+                    "scoreboard": {
+                        "Sammy": {
+                            "initial_coins": 2, "coins": 2, "range": 2,
+                            "points": 0, "stand_points": 0,
+                            "completed_challenges": [
+                                {
+                                    "winner": "Sammy", "player1": "Sammy", "player2": "Lee",
+                                    "player1Result": 3, "player2Result": 0,
+                                    "players": [ "Lee", "Sammy" ]
+                                },
+                            ]
+                        }
+                    }
+                }
+            )
+        ).toEqual([ ["Xotl"], ["Paco", "José"], [] ])
+
+        expect(
+            removeAlreadyChallengedPlayers(
+                [ ["Paco"], ["José", "Lee"], ["Sammy"] ],
+                "Minion",
+                {
+                    "scoreboard": {
+                        "Minion": {
+                            "initial_coins": 2, "coins": 2, "range": 2,
+                            "points": 0, "stand_points": 0,
+                            "completed_challenges": [
+                                {
+                                    "winner": "Minion", "player1": "Minion", "player2": "Lee",
+                                    "player1Result": 3, "player2Result": 0,
+                                    "players": [ "Lee", "Minion" ]
+                                },
+                            ]
+                        }
+                    }
+                }
+            )
+        ).toEqual([ ["Paco"], ["José"], ["Sammy"] ])
+    })
+
+
+    test('removeAlreadyChallengedPlayers', () => {
+        expect(
+            removeEmptyArray([ ["Paco"], [], ["Sammy"] ])
+        ).toEqual(
+            [ ["Paco"], ["Sammy"] ]
+        )
+    })
+
 })

--- a/src/utils.js
+++ b/src/utils.js
@@ -82,6 +82,23 @@ const removesBotTagFromString = msg => {
     return msg.replace(new RegExp(`<@${Config.bot_id}>`, 'gm'), '').trim()
 }
 
+const removeAlreadyChallengedPlayers = (players, playerId, in_progress) => {
+    const { scoreboard } = in_progress
+    const { completed_challenges } = scoreboard[playerId]
+
+    return players.map(rankPlayers => rankPlayers.filter(id => {
+        let canBeChallenged = null;
+
+        for (const i in completed_challenges) {
+            canBeChallenged = (completed_challenges[i].player1 === id || completed_challenges[i].player2 === id) ? false : true
+        }
+
+        return canBeChallenged
+    }))
+}
+
+const removeEmptyArray = array => array.filter(i => (i.length === 0) ? false : true)
+
 module.exports = {
     GetDateObjFromEpochTS,
     GetEpochUnixFromDate,
@@ -93,4 +110,6 @@ module.exports = {
     templateString,
     getRandomMessageById,
     removesBotTagFromString,
+    removeAlreadyChallengedPlayers,
+    removeEmptyArray,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -84,17 +84,20 @@ const removesBotTagFromString = msg => {
 
 const removeAlreadyChallengedPlayers = (players, playerId, in_progress) => {
     const { scoreboard } = in_progress
-    const { completed_challenges } = scoreboard[playerId]
+    const { completed_challenges = [] } = scoreboard[playerId] || {}
 
-    return players.map(rankPlayers => rankPlayers.filter(id => {
-        let canBeChallenged = null;
-
-        for (const i in completed_challenges) {
-            canBeChallenged = (completed_challenges[i].player1 === id || completed_challenges[i].player2 === id) ? false : true
-        }
-
-        return canBeChallenged
-    }))
+    return players.map(
+        rankPlayers => rankPlayers.filter(
+            id => {
+                for (const challenge of completed_challenges) {
+                    if ( challenge.players.includes(id) && challenge.winner === playerId ) {
+                        return false
+                    }
+                }
+                return true
+            }
+        )
+    )
 }
 
 const removeEmptyArray = array => array.filter(i => (i.length === 0) ? false : true)


### PR DESCRIPTION
## What does this do?
We added a filter so once a player asks for the players that he can challenge it only shows the players that he can challenge without the ones already challenged.

Currently, if a player asks for the available challenges, the bot displays every player.

## How can this change be undone in case of failure?

1. Notify the administrators
2. Request a revert of the PR


ping @Xotl


NOTE: this is a change introduced by @metalvegetarianoprogresivo and requires the PR #58 