### PR TITLE
Now players can challenge people in same rank

### DIFF
--- a/src/smash-league.js
+++ b/src/smash-league.js
@@ -64,8 +64,9 @@ const isReportedResultValid = (identifiedPlayersObj, rankingTable, playerScorebo
         playerChallengedId, playerChallengedPlace
     } = identifiedPlayersObj
 
-    if (challengerPlace === playerChallengedPlace) {// They cannot challenge people in the same place
-        logIgnoredMatch(`Ignored result between players "${getPlayerAlias(challengerId)}" & "${getPlayerAlias(playerChallengedId)}" because they are in the same place.`, reportedResult)
+    if (challengerPlace === playerChallengedPlace && challengerPlace <= 5) {
+        // They cannot challenge people in the same place above place 5
+        logIgnoredMatch(`Ignored result between players "${getPlayerAlias(challengerId)}" & "${getPlayerAlias(playerChallengedId)}" because they are in the same place if you're top 5.`, reportedResult)
         return false
     }
 
@@ -292,5 +293,6 @@ module.exports = {
     calculatePointsFromPlayerScore,
     getNextWeekObject,
     getUnrankedPlayerScore,
-    getPlayersThatCanBeChallenged
+    getPlayersThatCanBeChallenged,
+    isReportedResultValid
 }

--- a/src/tests/smash-league.test.js
+++ b/src/tests/smash-league.test.js
@@ -6,7 +6,7 @@ const {
 
 const {
     getNextWeekObject, calculatePointsFromPlayerScore, updateInProgressScoreboard,
-    commitInProgress
+    commitInProgress, isReportedResultValid
 } = require('../smash-league')
 
 
@@ -124,5 +124,60 @@ describe('Smash League Challenges & Scoreboard', () => {
                 "completed_challenges": []
             }
         })
+    })
+
+    test('isReportedResultValid', () => {
+        const rankingTable = [
+            ['Xotl'],
+            ['José', 'Lee'],
+            ['Paco'],
+            ['Neku'],
+            ['Roberto']
+        ]
+
+        expect(
+            isReportedResultValid(
+                {
+                    challengerId: 'Medininja', challengerPlace: 6,
+                    playerChallengedId: 'Manco', playerChallengedPlace: 6
+                },
+                rankingTable,
+                {
+                    "initial_coins": 2, "coins": 2, "range": 2,
+                    "points": 0, "stand_points": 0, "completed_challenges": []
+                },
+                {}
+            )
+        ).toBe(true)
+
+        expect(
+            isReportedResultValid(
+                {
+                    challengerId: 'Medininja', challengerPlace: 6,
+                    playerChallengedId: 'Paco', playerChallengedPlace: 4
+                },
+                rankingTable,
+                {
+                    "initial_coins": 2, "coins": 2, "range": 2,
+                    "points": 0, "stand_points": 0, "completed_challenges": []
+                },
+                {}
+            )
+        ).toBe(true)
+
+        expect(
+            isReportedResultValid(
+                {
+                    challengerId: 'Medininja', challengerPlace: 6,
+                    playerChallengedId: 'Xotl', playerChallengedPlace: 1
+                },
+                rankingTable,
+                {
+                    "initial_coins": 2, "coins": 2, "range": 2,
+                    "points": 0, "stand_points": 0, "completed_challenges": []
+                },
+                {}
+            )
+        ).toBe(false)
     })
 })


### PR DESCRIPTION
## What does this do?
Now players can challenge people in same rank but only if they're below rank 5.

## How can this change be undone in case of failure?

1. Notify the administrators
2. Request a revert of the PR

ping @Xotl
