### PR TITLE
Adjusting range because Angel is on vacation

### DIFF
--- a/ranking-info/ranking.json
+++ b/ranking-info/ranking.json
@@ -506,9 +506,9 @@
             "UDR61HJCD": {
                 "initial_coins": 1,
                 "coins": 1,
-                "range": 1,
+                "range": 2,
                 "points": 20,
-                "stand_points": 0,
+                "stand_points": -1,
                 "completed_challenges": []
             },
             "UBD38N45P": {


### PR DESCRIPTION
## What does this do?
Adjusts Sammy's range because Angel is on vacation.

## This PR fixes #XXX
...

(If it close any current issue, tag it.)

## Picture / GIF of the solution
...

## Closing issues

Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).

## How can this change be undone in case of failure?

1. Notify the administrators
2. Request a revert of the PR


ping @Xotl
