### PR TITLE
New rules for "Untie matches"

### DIFF
--- a/src/smash-league.js
+++ b/src/smash-league.js
@@ -78,6 +78,15 @@ const isReportedResultValid = (identifiedPlayersObj, rankingTable, challenger, p
             logIgnoredMatch(`Ignored result between players "${getPlayerAlias(challengerId)}" & "${getPlayerAlias(playerChallengedId)}" because they are in the same place but at least one of them has 0 coins.`, reportedResult)
             return false
         }
+
+        if (
+            doesPlayerChallengedAlreadyWonAgainstThatChallenger(challengerId, playerChallenged.completed_challenges) ||
+            doesPlayerChallengedAlreadyWonAgainstThatChallenger(playerChallengedId, challenger.completed_challenges)
+        ) {
+            // They cannot challenge each each other more than once if both are in same place
+            logIgnoredMatch(`Ignored result between players "${getPlayerAlias(challengerId)}" & "${getPlayerAlias(playerChallengedId)}" because they already reported the untie match before.`, reportedResult)
+            return false
+        }
     }
     
 

--- a/src/tests/smash-league.test.constants.js
+++ b/src/tests/smash-league.test.constants.js
@@ -388,5 +388,11 @@ module.exports = {
             player1Result: 1, player2Result: 3,
             players: ['UDBD59WLT', 'U61MBQTR8']
         },
+        {// Valid index #11: Two unranked players fight each other
+            winner: 'Unranked player',
+            player1: 'Another unranked player', player2: 'Unranked player',
+            player1Result: 1, player2Result: 3,
+            players: ['Another unranked player', 'Unranked player']
+        },
     ]
 }

--- a/src/tests/smash-league.test.constants.js
+++ b/src/tests/smash-league.test.constants.js
@@ -394,5 +394,11 @@ module.exports = {
             player1Result: 1, player2Result: 3,
             players: ['Another unranked player', 'Unranked player']
         },
+        {// Invalid index #12: Because they already played an untie match against each other
+            winner: 'Another unranked player',
+            player1: 'Unranked player', player2: 'Another unranked player',
+            player1Result: 1, player2Result: 3,
+            players: ['Unranked player', 'Another unranked player']
+        },
     ]
 }

--- a/src/tests/smash-league.test.js
+++ b/src/tests/smash-league.test.js
@@ -151,18 +151,18 @@ describe('Smash League Challenges & Scoreboard', () => {
             ['Roberto']
         ]
 
+        const unrankedScore = {
+            "initial_coins": 2, "coins": 2, "range": 2,
+            "points": 0, "stand_points": 0, "completed_challenges": []
+        }
+
         expect(
             isReportedResultValid(
                 {
                     challengerId: 'Medininja', challengerPlace: 6,
                     playerChallengedId: 'Manco', playerChallengedPlace: 6
                 },
-                rankingTable,
-                {
-                    "initial_coins": 2, "coins": 2, "range": 2,
-                    "points": 0, "stand_points": 0, "completed_challenges": []
-                },
-                {}
+                rankingTable, unrankedScore, unrankedScore, {}
             )
         ).toBe(true)
 
@@ -177,7 +177,7 @@ describe('Smash League Challenges & Scoreboard', () => {
                     "initial_coins": 2, "coins": 2, "range": 2,
                     "points": 0, "stand_points": 0, "completed_challenges": []
                 },
-                {}
+                unrankedScore, unrankedScore, {}
             )
         ).toBe(true)
 
@@ -187,12 +187,7 @@ describe('Smash League Challenges & Scoreboard', () => {
                     challengerId: 'Medininja', challengerPlace: 6,
                     playerChallengedId: 'Xotl', playerChallengedPlace: 1
                 },
-                rankingTable,
-                {
-                    "initial_coins": 2, "coins": 2, "range": 2,
-                    "points": 0, "stand_points": 0, "completed_challenges": []
-                },
-                {}
+                rankingTable, unrankedScore, unrankedScore, {}
             )
         ).toBe(false)
     })

--- a/src/tests/smash-league.test.js
+++ b/src/tests/smash-league.test.js
@@ -122,7 +122,23 @@ describe('Smash League Challenges & Scoreboard', () => {
                 "coins": 0,
                 "range": 0,
                 "completed_challenges": []
-            }
+            },
+            "Another unranked player": {
+                "initial_coins": 3,
+                "stand_points": 0,
+                "points": 0,
+                "coins": 2,
+                "range": 3,
+                "completed_challenges": [ ACTIVITIES1[11] ]
+            },
+            "Unranked player": {
+                "initial_coins": 3,
+                "stand_points": 1,
+                "points": 0,
+                "coins": 3,
+                "range": 3,
+                "completed_challenges": [ ACTIVITIES1[11] ]
+            },
         })
     })
 


### PR DESCRIPTION
## What does this do?
Now that players can play *Untie matches*, the score obeys to the new rules:

* The winner of an *untie match* gains  1 _stand_point_.
* The loser of an *untie match* loses 1 coin.
* Both players can't play again an *untie match* against each other.

**Note:** An *Untie match* is a match between players that are in the same rank level.

## How can this change be undone in case of failure?

1. Notify the administrators
2. Request a revert of the PR


ping @Xotl
