### PR TITLE
Add Elo Formula calculation to utils

### DIFF
--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -3,7 +3,7 @@
 const {
     GetEpochUnixFromDate, GetDateObjFromEpochTS, setIgnoredActivityLogObject, logIgnoredActivity,
     logIgnoredMatch, showInConsoleIgnoredActivities, removeAlreadyChallengedPlayers, 
-    removeEmptyArray
+    removeEmptyArray, eloCalculation
 } = require('../utils')
 
 
@@ -114,6 +114,60 @@ describe('Utils', () => {
         ).toEqual(
             [ ["Paco"], ["Sammy"] ]
         )
+    })
+
+    test('EloCalculateForPlayerAIFPlayerAIsBetterAndWinsBy3to2', () => {
+        expect(
+            eloCalculation(100, 50, 3, 2)
+        ).toEqual({
+            playerANewElo: 125,
+            playerBNewElo: 65
+        })
+    })
+
+    test('EloCalculateForPlayerBIFPlayerAIsBetterAndWinsBy3to2', () => {
+        expect(
+            eloCalculation(100, 50, 2, 3)
+        ).toEqual({
+            playerANewElo: 115,
+            playerBNewElo: 75
+        })
+    })
+
+    test('EloCalculateForPlayerAIFPlayerAIsBetterAndWinsBy3to0', () => {
+        expect(
+            eloCalculation(100, 50, 3, 0)
+        ).toEqual({
+            playerANewElo: 125,
+            playerBNewElo: 45
+        })
+    })
+
+    test('EloCalculateForPlayerBIFPlayerAIsBetterAndWinsBy3to0', () => {
+        expect(
+            eloCalculation(100, 50, 0, 3)
+        ).toEqual({
+            playerANewElo: 95,
+            playerBNewElo: 75
+        })
+    })
+
+    test('EloCalculateForPlayerAIFSimilarEloAndWinsBy3to0', () => {
+        expect(
+            eloCalculation(100, 100, 3, 0)
+        ).toEqual({
+            playerANewElo: 125,
+            playerBNewElo: 95
+        })
+    })
+
+    test('EloCalculateForPlayerBIFAIsAGodAndWinsBy3to0', () => {
+        expect(
+            eloCalculation(1000, 100, 0, 3)
+        ).toEqual({
+            playerANewElo: 995,
+            playerBNewElo: 125
+        })
     })
 
 })

--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -118,55 +118,55 @@ describe('Utils', () => {
 
     test('EloCalculateForPlayerAIFPlayerAIsBetterAndWinsBy3to2', () => {
         expect(
-            eloCalculation(100, 50, 3, 2)
+            eloCalculation(2400, 1500, 3, 2)
         ).toEqual({
-            playerANewElo: 125,
-            playerBNewElo: 65
+            playerANewElo: 2480,
+            playerBNewElo: 1548
         })
     })
 
     test('EloCalculateForPlayerBIFPlayerAIsBetterAndWinsBy3to2', () => {
         expect(
-            eloCalculation(100, 50, 2, 3)
+            eloCalculation(2500, 1500, 2, 3)
         ).toEqual({
-            playerANewElo: 115,
-            playerBNewElo: 75
+            playerANewElo: 2548,
+            playerBNewElo: 1580
         })
     })
 
     test('EloCalculateForPlayerAIFPlayerAIsBetterAndWinsBy3to0', () => {
         expect(
-            eloCalculation(100, 50, 3, 0)
+            eloCalculation(2500, 1500, 3, 0)
         ).toEqual({
-            playerANewElo: 125,
-            playerBNewElo: 45
+            playerANewElo: 2580,
+            playerBNewElo: 1484
         })
     })
 
     test('EloCalculateForPlayerBIFPlayerAIsBetterAndWinsBy3to0', () => {
         expect(
-            eloCalculation(100, 50, 0, 3)
+            eloCalculation(2500, 1500, 0, 3)
         ).toEqual({
-            playerANewElo: 95,
-            playerBNewElo: 75
+            playerANewElo: 2484,
+            playerBNewElo: 1580
         })
     })
 
     test('EloCalculateForPlayerAIFSimilarEloAndWinsBy3to0', () => {
         expect(
-            eloCalculation(100, 100, 3, 0)
+            eloCalculation(1500, 1500, 3, 0)
         ).toEqual({
-            playerANewElo: 125,
-            playerBNewElo: 95
+            playerANewElo: 1580,
+            playerBNewElo: 1484
         })
     })
 
     test('EloCalculateForPlayerBIFAIsAGodAndWinsBy3to0', () => {
         expect(
-            eloCalculation(1000, 100, 0, 3)
+            eloCalculation(3000, 1000, 0, 3)
         ).toEqual({
-            playerANewElo: 995,
-            playerBNewElo: 125
+            playerANewElo: 2984,
+            playerBNewElo: 1080
         })
     })
 

--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -120,7 +120,7 @@ describe('Utils', () => {
         expect(
             eloCalculation(2400, 1500, 3, 2)
         ).toEqual({
-            playerANewElo: 2480,
+            playerANewElo: 2460,
             playerBNewElo: 1548
         })
     })
@@ -129,7 +129,7 @@ describe('Utils', () => {
         expect(
             eloCalculation(2500, 1500, 2, 3)
         ).toEqual({
-            playerANewElo: 2548,
+            playerANewElo: 2524,
             playerBNewElo: 1580
         })
     })
@@ -138,7 +138,7 @@ describe('Utils', () => {
         expect(
             eloCalculation(2500, 1500, 3, 0)
         ).toEqual({
-            playerANewElo: 2580,
+            playerANewElo: 2540,
             playerBNewElo: 1484
         })
     })
@@ -147,7 +147,7 @@ describe('Utils', () => {
         expect(
             eloCalculation(2500, 1500, 0, 3)
         ).toEqual({
-            playerANewElo: 2484,
+            playerANewElo: 2492,
             playerBNewElo: 1580
         })
     })
@@ -165,7 +165,7 @@ describe('Utils', () => {
         expect(
             eloCalculation(3000, 1000, 0, 3)
         ).toEqual({
-            playerANewElo: 2984,
+            playerANewElo: 2992,
             playerBNewElo: 1080
         })
     })

--- a/src/utils.js
+++ b/src/utils.js
@@ -103,16 +103,13 @@ const removeAlreadyChallengedPlayers = (players, playerId, in_progress) => {
 const removeEmptyArray = array => array.filter(i => (i.length === 0) ? false : true)
 
 const factorKCaculator = elo => {
-    switch (elo) {
-        case (elo < 2100):
-            return 32
-        case (elo >= 2100 && elo <= 2400):
-            return 24
-        case (elo > 2400):
-            return 16
-        default:
-            return 32
-    }
+    if (elo < 2100)
+        return 32
+
+    if (elo >= 2100 && elo <= 2400)
+        return 24
+
+    return 16
 }
 
 const eloCalculation = (playerAElo, playerBElo, playerAScore, playerBScore) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -102,13 +102,26 @@ const removeAlreadyChallengedPlayers = (players, playerId, in_progress) => {
 
 const removeEmptyArray = array => array.filter(i => (i.length === 0) ? false : true)
 
+const factorKCaculator = elo => {
+    switch (elo) {
+        case (elo < 2100):
+            return 32
+        case (elo >= 2100 && elo <= 2400):
+            return 24
+        case (elo > 2400):
+            return 16
+        default:
+            return 32
+    }
+}
+
 const eloCalculation = (playerAElo, playerBElo, playerAScore, playerBScore) => {
     const probabilityOfWinPlayerA = 1.0 * 1.0 / (1 + 1.0 * Math.pow(1, 1.0 * (playerAElo - playerBElo) / 400))
     const probabilityOfWinPlayerB = 1.0 * 1.0 / (1 + 1.0 * Math.pow(1, 1.0 * (playerBElo - playerAElo) / 400))
 
     return {
-        playerANewElo: playerAElo + 10 * (playerAScore - probabilityOfWinPlayerA),
-        playerBNewElo: playerBElo + 10 * (playerBScore - probabilityOfWinPlayerB),
+        playerANewElo: playerAElo + factorKCaculator(playerAElo) * (playerAScore - probabilityOfWinPlayerA),
+        playerBNewElo: playerBElo + factorKCaculator(playerBElo) * (playerBScore - probabilityOfWinPlayerB),
     }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -102,6 +102,16 @@ const removeAlreadyChallengedPlayers = (players, playerId, in_progress) => {
 
 const removeEmptyArray = array => array.filter(i => (i.length === 0) ? false : true)
 
+const eloCalculation = (playerAElo, playerBElo, playerAScore, playerBScore) => {
+    const probabilityOfWinPlayerA = 1.0 * 1.0 / (1 + 1.0 * Math.pow(1, 1.0 * (playerAElo - playerBElo) / 400))
+    const probabilityOfWinPlayerB = 1.0 * 1.0 / (1 + 1.0 * Math.pow(1, 1.0 * (playerBElo - playerAElo) / 400))
+
+    return {
+        playerANewElo: playerAElo + 10 * (playerAScore - probabilityOfWinPlayerA),
+        playerBNewElo: playerBElo + 10 * (playerBScore - probabilityOfWinPlayerB),
+    }
+}
+
 module.exports = {
     GetDateObjFromEpochTS,
     GetEpochUnixFromDate,
@@ -115,4 +125,5 @@ module.exports = {
     removesBotTagFromString,
     removeAlreadyChallengedPlayers,
     removeEmptyArray,
+    eloCalculation,
 }


### PR DESCRIPTION
## What does this do?
We added a formula to calculate the new values of the ELO of a player's match.

## How can this change be undone in case of failure?

1. Notify the administrators
2. Request a revert of the PR


ping @Xotl
