### PR TITLE
Update scoreboard to use Elo

### DIFF
--- a/ranking-info/README.md
+++ b/ranking-info/README.md
@@ -13,11 +13,11 @@ Last updated **Sun, 13 Oct 2019 17:49:15 GMT**.
 |7|`Sammy`|1800|
 |8|`El Minion`|1700|
 
-Unranked players and players that have 0 points will start with this score:
+Unranked players and players that have less than 1000 Elo points will start with this score:
 
 |Coins|Range|Stand points|Points|
 |-----|-----|------------|------|
-|2|2|0|0|
+|2|2|0|1000|
 
 ## In progress this week *Sun, 13 Oct 2019 17:49:15 GMT*
 This section shows the progress of the week. Every sunday the below categories will be reseted and the Ranking will get updated.

--- a/ranking-info/README.md
+++ b/ranking-info/README.md
@@ -4,15 +4,14 @@ Last updated **Sun, 13 Oct 2019 17:49:15 GMT**.
 
 |#|Player|Score|
 |-|------|-----|
-|1|`Xotl`|33|
-|2|`Paco`|28|
-|3|`José "El Iceberg" Rosales`|27|
-|4|`Angel Lee`|24|
-|5|`Sammy`|20|
-|6|`Roberto`|19|
-|7|`Neku`|18|
-|8|`El Minion`|17|
-|9|`Alfredo`|3|
+|1|`Xotl`|2400|
+|2|`Paco`|2300|
+|3|`Roberto`|2200|
+|4|`Neku`|2100|
+|5|`Angel Lee`|2000|
+|6|`José "El Iceberg" Rosales`|1900|
+|7|`Sammy`|1800|
+|8|`El Minion`|1700|
 
 Unranked players and players that have 0 points will start with this score:
 
@@ -28,26 +27,26 @@ The current points earned by winning matches this week.
 
 |Player|Coins|Range|Stand points|Score|
 |------|-----|-----|------------|-----|
-|Xotl|0|0|0|33|
-|Paco|1|1|0|28|
-|José "El Iceberg" Rosales|1|1|0|27|
-|Angel Lee|1|1|0|24|
-|Sammy|1|1|0|20|
-|Roberto|2|2|0|19|
-|Neku|2|2|0|18|
-|El Minion|2|2|0|17|
-|Alfredo|2|2|0|3|
-|Carlos López|2|2|0|0|
-|Alan|2|2|0|0|
-|El Chino|2|2|0|0|
-|César Gutman|2|2|0|0|
-|D.I.O.|2|2|0|0|
-|Michel|2|2|0|0|
-|Niightz|2|2|0|0|
-|David|2|2|0|0|
-|Medininja|2|2|0|0|
-|El Plebe|2|2|0|0|
-|Paolo|2|2|0|0|
+|Xotl|0|0|0|2400|
+|Paco|1|1|0|2300|
+|Roberto|2|2|0|2200|
+|Neku|2|2|0|2100|
+|Angel Lee|1|1|0|2000|
+|José "El Iceberg" Rosales|1|1|0|1900|
+|Sammy|1|1|0|1800|
+|El Minion|2|2|0|1700|
+|Alfredo|2|2|0|1600|
+|D.I.O.|2|2|0|1510|
+|Paolo|2|2|0|1500|
+|El Chino|2|2|0|1495|
+|El Plebe|2|2|0|1490|
+|Alan|2|2|0|1480|
+|Niightz|2|2|0|1470|
+|Michel|2|2|0|1440|
+|Medininja|2|2|0|1420|
+|David|2|2|0|1000|
+|César Gutman|2|2|0|1000|
+|Carlos López|2|2|0|1000|
 
 ### Completed challenges
 Matches that already happened during this week.

--- a/ranking-info/ranking.json
+++ b/ranking-info/ranking.json
@@ -1,5 +1,5 @@
 {
-    "last_update_ts": 1570988955882,
+    "last_update_ts": 1572242400000,
     "season": {
         "start": 1562511600001,
         "end": 1573142400001
@@ -42,7 +42,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 0,
+            "points": 1000,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -50,7 +50,7 @@
             "initial_coins": 0,
             "coins": 0,
             "range": 0,
-            "points": 33,
+            "points": 2400,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -58,7 +58,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 0,
+            "points": 1480,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -66,7 +66,7 @@
             "initial_coins": 1,
             "coins": 1,
             "range": 1,
-            "points": 24,
+            "points": 2000,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -74,7 +74,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 0,
+            "points": 1495,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -82,7 +82,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 0,
+            "points": 1000,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -90,7 +90,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 17,
+            "points": 1700,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -98,7 +98,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 18,
+            "points": 2100,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -106,7 +106,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 0,
+            "points": 1510,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -114,7 +114,7 @@
             "initial_coins": 1,
             "coins": 1,
             "range": 1,
-            "points": 27,
+            "points": 1900,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -122,7 +122,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 0,
+            "points": 1440,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -130,7 +130,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 0,
+            "points": 1470,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -138,7 +138,7 @@
             "initial_coins": 1,
             "coins": 1,
             "range": 1,
-            "points": 20,
+            "points": 1800,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -146,7 +146,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 0,
+            "points": 1000,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -154,7 +154,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 0,
+            "points": 1420,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -162,7 +162,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 0,
+            "points": 1490,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -170,7 +170,7 @@
             "initial_coins": 1,
             "coins": 1,
             "range": 1,
-            "points": 28,
+            "points": 2300,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -178,7 +178,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 0,
+            "points": 1500,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -186,7 +186,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 19,
+            "points": 220,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -194,7 +194,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 3,
+            "points": 1600,
             "stand_points": 0,
             "completed_challenges": []
         }
@@ -206,7 +206,7 @@
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 0,
+                "points": 1000,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -214,7 +214,7 @@
                 "initial_coins": 0,
                 "coins": 0,
                 "range": 0,
-                "points": 33,
+                "points": 2400,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -222,7 +222,7 @@
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 0,
+                "points": 1480,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -231,14 +231,14 @@
                 "coins": 1,
                 "range": 1,
                 "points": 24,
-                "stand_points": 0,
+                "stand_points": 2000,
                 "completed_challenges": []
             },
             "UEWUZCYJF": {
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 0,
+                "points": 1495,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -247,21 +247,21 @@
                 "coins": 2,
                 "range": 2,
                 "points": 0,
-                "stand_points": 0,
+                "stand_points": 1000,
                 "completed_challenges": []
             },
             "U8M6QT7EF": {
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 17,
+                "points": 1700,
                 "stand_points": 0,
                 "completed_challenges": []
             },
             "U8THDCVJ7": {
                 "initial_coins": 2,
                 "coins": 2,
-                "range": 2,
+                "range": 2100,
                 "points": 18,
                 "stand_points": 0,
                 "completed_challenges": []
@@ -270,7 +270,7 @@
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 0,
+                "points": 1510,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -278,7 +278,7 @@
                 "initial_coins": 1,
                 "coins": 1,
                 "range": 1,
-                "points": 27,
+                "points": 1900,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -286,7 +286,7 @@
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 0,
+                "points": 1440,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -294,7 +294,7 @@
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 0,
+                "points": 1470,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -302,7 +302,7 @@
                 "initial_coins": 1,
                 "coins": 1,
                 "range": 1,
-                "points": 20,
+                "points": 1800,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -310,7 +310,7 @@
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 0,
+                "points": 1000,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -318,7 +318,7 @@
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 0,
+                "points": 1420,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -326,7 +326,7 @@
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 0,
+                "points": 1490,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -334,7 +334,7 @@
                 "initial_coins": 1,
                 "coins": 1,
                 "range": 1,
-                "points": 28,
+                "points": 2300,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -342,7 +342,7 @@
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 0,
+                "points": 1500,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -350,7 +350,7 @@
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 19,
+                "points": 220,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -358,14 +358,14 @@
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 3,
+                "points": 1600,
                 "stand_points": 0,
                 "completed_challenges": []
             }
         },
         "active_challenges": {},
         "completed_challenges": [],
-        "last_update_ts": 1570988955882,
+        "last_update_ts": 1572242400000,
         "reported_results": []
     }
 }

--- a/ranking-info/ranking.json
+++ b/ranking-info/ranking.json
@@ -186,7 +186,7 @@
             "initial_coins": 2,
             "coins": 2,
             "range": 2,
-            "points": 220,
+            "points": 2200,
             "stand_points": 0,
             "completed_challenges": []
         },
@@ -230,8 +230,8 @@
                 "initial_coins": 1,
                 "coins": 1,
                 "range": 1,
-                "points": 24,
-                "stand_points": 2000,
+                "points": 2000,
+                "stand_points": 0,
                 "completed_challenges": []
             },
             "UEWUZCYJF": {
@@ -261,8 +261,8 @@
             "U8THDCVJ7": {
                 "initial_coins": 2,
                 "coins": 2,
-                "range": 2100,
-                "points": 18,
+                "range": 2,
+                "points": 2100,
                 "stand_points": 0,
                 "completed_challenges": []
             },
@@ -350,7 +350,7 @@
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 220,
+                "points": 2200,
                 "stand_points": 0,
                 "completed_challenges": []
             },


### PR DESCRIPTION
## What does this do?
This PR updates the current scoreboard with the new Elo system. Now the players have an updated points system. 

## Picture / GIF of the solution
![image](https://user-images.githubusercontent.com/1013633/67629426-5db2b180-f843-11e9-84dd-538f5cdd886c.png)

## How can this change be undone in case of failure?

1. Notify the administrators
2. Request a revert of the PR


ping @Xotl
