### PR TITLE
Fix Elo issue with the player challenged losing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smash-league",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smash-league",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smash-league",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smash-league",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/ranking-info/README.md
+++ b/ranking-info/README.md
@@ -29,7 +29,7 @@ Unranked players and players that have 0 points will start with this score:
 |-----|-----|------|
 |4|4|1000|
 
-## In progress this week *Tue, 29 Oct 2019 06:39:28 GMT*
+## In progress this week *Wed, 30 Oct 2019 06:39:41 GMT*
 This section shows the progress of the week. Every sunday the below categories will be reseted and the Ranking will get updated.
 
 ### Current Scoreboard
@@ -40,9 +40,9 @@ The current points earned by winning matches this week.
 |Xotl|0|0|2400|
 |Paco|1|1|2300|
 |Roberto|1|1|2200|
-|José "El Iceberg" Rosales|2|3|2125|
+|José "El Iceberg" Rosales|2|4|2184|
 |Neku|1|1|2100|
-|Angel Lee|1|1|2000|
+|Angel Lee|1|2|2052|
 |Sammy|0|2|1785|
 |El Minion|2|2|1700|
 |Alfredo|2|2|1600|
@@ -61,6 +61,8 @@ The current points earned by winning matches this week.
 ### Completed challenges
 Matches that already happened during this week.
 
+* `Angel Lee` challenged `Neku` and **won** *3-1*.
 * `José "El Iceberg" Rosales` challenged `Angel Lee` and **won** *3-0*.
+* `José "El Iceberg" Rosales` challenged `Neku` and **won** *3-0*.
 * `Sammy` challenged `José "El Iceberg" Rosales` and **lost** *3-0*.
 * `Sammy` challenged `José "El Iceberg" Rosales` and **lost** *3-0*.

--- a/ranking-info/README.md
+++ b/ranking-info/README.md
@@ -1,6 +1,6 @@
 # Ranking
 
-Last updated **Mon, 28 Oct 2019 04:00:42 GMT**.
+Last updated **Mon, 28 Oct 2019 06:39:15 GMT**.
 
 |#|Player|Score|
 |-|------|-----|
@@ -29,7 +29,7 @@ Unranked players and players that have 0 points will start with this score:
 |-----|-----|------|
 |4|4|1000|
 
-## In progress this week *Mon, 28 Oct 2019 04:00:42 GMT*
+## In progress this week *Mon, 28 Oct 2019 06:39:15 GMT*
 This section shows the progress of the week. Every sunday the below categories will be reseted and the Ranking will get updated.
 
 ### Current Scoreboard

--- a/ranking-info/README.md
+++ b/ranking-info/README.md
@@ -29,7 +29,7 @@ Unranked players and players that have 0 points will start with this score:
 |-----|-----|------|
 |4|4|1000|
 
-## In progress this week *Wed, 30 Oct 2019 06:39:41 GMT*
+## In progress this week *Thu, 31 Oct 2019 06:40:07 GMT*
 This section shows the progress of the week. Every sunday the below categories will be reseted and the Ranking will get updated.
 
 ### Current Scoreboard
@@ -39,16 +39,16 @@ The current points earned by winning matches this week.
 |------|-----|-----|-----|
 |Xotl|0|0|2400|
 |Paco|1|1|2300|
-|Roberto|1|1|2200|
-|José "El Iceberg" Rosales|2|4|2184|
-|Neku|1|1|2100|
-|Angel Lee|1|2|2052|
+|Roberto|1|2|2299|
+|José "El Iceberg" Rosales|0|6|2234|
+|Neku|0|1|2092|
+|Angel Lee|0|2|2042|
 |Sammy|0|2|1785|
-|El Minion|2|2|1700|
+|El Minion|2|2|1739|
 |Alfredo|2|2|1600|
 |D.I.O.|2|2|1510|
-|Paolo|3|3|1500|
 |El Chino|3|3|1495|
+|Paolo|2|3|1492|
 |El Plebe|3|3|1490|
 |Alan|3|3|1480|
 |Niightz|3|3|1470|
@@ -62,7 +62,13 @@ The current points earned by winning matches this week.
 Matches that already happened during this week.
 
 * `Angel Lee` challenged `Neku` and **won** *3-1*.
+* `Angel Lee` challenged `Roberto` and **lost** *3-1*.
+* `Neku` challenged `Roberto` and **lost** *3-1*.
 * `José "El Iceberg" Rosales` challenged `Angel Lee` and **won** *3-0*.
 * `José "El Iceberg" Rosales` challenged `Neku` and **won** *3-0*.
+* `José "El Iceberg" Rosales` challenged `Roberto` and **won** *3-1*.
+* `José "El Iceberg" Rosales` challenged `Paco` and **won** *3-2*.
 * `Sammy` challenged `José "El Iceberg" Rosales` and **lost** *3-0*.
 * `Sammy` challenged `José "El Iceberg" Rosales` and **lost** *3-0*.
+* `Paolo` challenged `El Minion` and **lost** *3-1*.
+* `Roberto` challenged `Paco` and **won** *3-1*.

--- a/ranking-info/README.md
+++ b/ranking-info/README.md
@@ -29,7 +29,7 @@ Unranked players and players that have 0 points will start with this score:
 |-----|-----|------|
 |4|4|1000|
 
-## In progress this week *Mon, 28 Oct 2019 06:39:15 GMT*
+## In progress this week *Tue, 29 Oct 2019 06:39:28 GMT*
 This section shows the progress of the week. Every sunday the below categories will be reseted and the Ranking will get updated.
 
 ### Current Scoreboard
@@ -40,10 +40,10 @@ The current points earned by winning matches this week.
 |Xotl|0|0|2400|
 |Paco|1|1|2300|
 |Roberto|1|1|2200|
+|José "El Iceberg" Rosales|2|3|2125|
 |Neku|1|1|2100|
 |Angel Lee|1|1|2000|
-|José "El Iceberg" Rosales|2|2|1900|
-|Sammy|2|2|1800|
+|Sammy|0|2|1785|
 |El Minion|2|2|1700|
 |Alfredo|2|2|1600|
 |D.I.O.|2|2|1510|
@@ -61,4 +61,6 @@ The current points earned by winning matches this week.
 ### Completed challenges
 Matches that already happened during this week.
 
-
+* `José "El Iceberg" Rosales` challenged `Angel Lee` and **won** *3-0*.
+* `Sammy` challenged `José "El Iceberg" Rosales` and **lost** *3-0*.
+* `Sammy` challenged `José "El Iceberg" Rosales` and **lost** *3-0*.

--- a/ranking-info/history-log.md
+++ b/ranking-info/history-log.md
@@ -1,3 +1,32 @@
+## Commit from Mon, 28 Oct 2019 06:39:15 GMT
+The week started at *Sun, 27 Oct 2019 15:00:00 GMT* and ended *Sun, 03 Nov 2019 15:00:00 GMT*.
+### End of week players score summary
+|Player|Coins|Range|
+|------|-----|-----|
+|Xotl - 2400pts|0|0|
+|Paco - 2300pts|1|1|
+|Roberto - 2200pts|1|1|
+|Neku - 2100pts|1|1|
+|Angel Lee - 2000pts|1|1|
+|José "El Iceberg" Rosales - 1900pts|2|2|
+|Sammy - 1800pts|2|2|
+|El Minion - 1700pts|2|2|
+|Alfredo - 1600pts|2|2|
+|D.I.O. - 1510pts|2|2|
+|Paolo - 1500pts|3|3|
+|El Chino - 1495pts|3|3|
+|El Plebe - 1490pts|3|3|
+|Alan - 1480pts|3|3|
+|Niightz - 1470pts|3|3|
+|Michel - 1440pts|4|4|
+|Medininja - 1420pts|4|4|
+|Carlos López - 1000pts|4|4|
+|David - 1000pts|4|4|
+|César Gutman - 0pts|4|4|
+### Completed challenges
+
+
+
 ## Commit from Mon, 28 Oct 2019 04:00:42 GMT
 The week started at *Sun, 20 Oct 2019 15:00:00 GMT* and ended *Sun, 27 Oct 2019 15:00:00 GMT*.
 ### End of week players score summary

--- a/ranking-info/ranking.json
+++ b/ranking-info/ranking.json
@@ -233,33 +233,10 @@
             },
             "UB616ENA0": {
                 "initial_coins": 1,
-                "coins": 0,
-                "range": 2,
-                "points": 2042,
-                "completed_challenges": [
-                    {
-                        "winner": "UB616ENA0",
-                        "player1": "U8THDCVJ7",
-                        "player2": "UB616ENA0",
-                        "player1Result": 1,
-                        "player2Result": 3,
-                        "players": [
-                            "U8THDCVJ7",
-                            "UB616ENA0"
-                        ]
-                    },
-                    {
-                        "winner": "UMY200LSC",
-                        "player1": "UMY200LSC",
-                        "player2": "UB616ENA0",
-                        "player1Result": 3,
-                        "player2Result": 1,
-                        "players": [
-                            "UMY200LSC",
-                            "UB616ENA0"
-                        ]
-                    }
-                ]
+                "coins": 1,
+                "range": 1,
+                "points": 2000,
+                "completed_challenges": []
             },
             "UEWUZCYJF": {
                 "initial_coins": 3,
@@ -279,27 +256,15 @@
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 1739,
+                "points": 1700,
                 "completed_challenges": []
             },
             "U8THDCVJ7": {
                 "initial_coins": 1,
-                "coins": 0,
+                "coins": 1,
                 "range": 1,
-                "points": 2092,
-                "completed_challenges": [
-                    {
-                        "winner": "UMY200LSC",
-                        "player1": "UMY200LSC",
-                        "player2": "U8THDCVJ7",
-                        "player1Result": 3,
-                        "player2Result": 1,
-                        "players": [
-                            "UMY200LSC",
-                            "U8THDCVJ7"
-                        ]
-                    }
-                ]
+                "points": 2100,
+                "completed_challenges": []
             },
             "U6457D5KQ": {
                 "initial_coins": 2,
@@ -310,55 +275,10 @@
             },
             "UBA5M220K": {
                 "initial_coins": 2,
-                "coins": 0,
-                "range": 6,
-                "points": 2234,
-                "completed_challenges": [
-                    {
-                        "winner": "UBA5M220K",
-                        "player1": "UB616ENA0",
-                        "player2": "UBA5M220K",
-                        "player1Result": 0,
-                        "player2Result": 3,
-                        "players": [
-                            "UB616ENA0",
-                            "UBA5M220K"
-                        ]
-                    },
-                    {
-                        "winner": "UBA5M220K",
-                        "player1": "U8THDCVJ7",
-                        "player2": "UBA5M220K",
-                        "player1Result": 0,
-                        "player2Result": 3,
-                        "players": [
-                            "U8THDCVJ7",
-                            "UBA5M220K"
-                        ]
-                    },
-                    {
-                        "winner": "UBA5M220K",
-                        "player1": "UMY200LSC",
-                        "player2": "UBA5M220K",
-                        "player1Result": 1,
-                        "player2Result": 3,
-                        "players": [
-                            "UMY200LSC",
-                            "UBA5M220K"
-                        ]
-                    },
-                    {
-                        "winner": "UBA5M220K",
-                        "player1": "UBA5M220K",
-                        "player2": "UKPTK422K",
-                        "player1Result": 3,
-                        "player2Result": 2,
-                        "players": [
-                            "UBA5M220K",
-                            "UKPTK422K"
-                        ]
-                    }
-                ]
+                "coins": 2,
+                "range": 2,
+                "points": 1900,
+                "completed_challenges": []
             },
             "UAGR4S57G": {
                 "initial_coins": 4,
@@ -376,33 +296,10 @@
             },
             "UDR61HJCD": {
                 "initial_coins": 2,
-                "coins": 0,
+                "coins": 2,
                 "range": 2,
-                "points": 1785,
-                "completed_challenges": [
-                    {
-                        "winner": "UBA5M220K",
-                        "player1": "UDR61HJCD",
-                        "player2": "UBA5M220K",
-                        "player1Result": 0,
-                        "player2Result": 3,
-                        "players": [
-                            "UDR61HJCD",
-                            "UBA5M220K"
-                        ]
-                    },
-                    {
-                        "winner": "UBA5M220K",
-                        "player1": "UDR61HJCD",
-                        "player2": "UBA5M220K",
-                        "player1Result": 0,
-                        "player2Result": 3,
-                        "players": [
-                            "UDR61HJCD",
-                            "UBA5M220K"
-                        ]
-                    }
-                ]
+                "points": 1800,
+                "completed_challenges": []
             },
             "UBD38N45P": {
                 "initial_coins": 4,
@@ -434,41 +331,17 @@
             },
             "UHHD243DH": {
                 "initial_coins": 3,
-                "coins": 2,
+                "coins": 3,
                 "range": 3,
-                "points": 1492,
-                "completed_challenges": [
-                    {
-                        "winner": "U8M6QT7EF",
-                        "player1": "UHHD243DH",
-                        "player2": "U8M6QT7EF",
-                        "player1Result": 1,
-                        "player2Result": 3,
-                        "players": [
-                            "UHHD243DH",
-                            "U8M6QT7EF"
-                        ]
-                    }
-                ]
+                "points": 1500,
+                "completed_challenges": []
             },
             "UMY200LSC": {
                 "initial_coins": 1,
                 "coins": 1,
-                "range": 2,
-                "points": 2299,
-                "completed_challenges": [
-                    {
-                        "winner": "UMY200LSC",
-                        "player1": "UMY200LSC",
-                        "player2": "UKPTK422K",
-                        "player1Result": 3,
-                        "player2Result": 1,
-                        "players": [
-                            "UMY200LSC",
-                            "UKPTK422K"
-                        ]
-                    }
-                ]
+                "range": 1,
+                "points": 2200,
+                "completed_challenges": []
             },
             "ULBS05D3M": {
                 "initial_coins": 2,
@@ -480,7 +353,7 @@
         },
         "active_challenges": {},
         "completed_challenges": [],
-        "last_update_ts": 1572504007283,
+        "last_update_ts": 1572244755919,
         "reported_results": []
     }
 }

--- a/ranking-info/ranking.json
+++ b/ranking-info/ranking.json
@@ -234,9 +234,21 @@
             "UB616ENA0": {
                 "initial_coins": 1,
                 "coins": 1,
-                "range": 1,
-                "points": 2000,
-                "completed_challenges": []
+                "range": 2,
+                "points": 2052,
+                "completed_challenges": [
+                    {
+                        "winner": "UB616ENA0",
+                        "player1": "U8THDCVJ7",
+                        "player2": "UB616ENA0",
+                        "player1Result": 1,
+                        "player2Result": 3,
+                        "players": [
+                            "U8THDCVJ7",
+                            "UB616ENA0"
+                        ]
+                    }
+                ]
             },
             "UEWUZCYJF": {
                 "initial_coins": 3,
@@ -276,8 +288,8 @@
             "UBA5M220K": {
                 "initial_coins": 2,
                 "coins": 2,
-                "range": 3,
-                "points": 2125,
+                "range": 4,
+                "points": 2184,
                 "completed_challenges": [
                     {
                         "winner": "UBA5M220K",
@@ -287,6 +299,17 @@
                         "player2Result": 3,
                         "players": [
                             "UB616ENA0",
+                            "UBA5M220K"
+                        ]
+                    },
+                    {
+                        "winner": "UBA5M220K",
+                        "player1": "U8THDCVJ7",
+                        "player2": "UBA5M220K",
+                        "player1Result": 0,
+                        "player2Result": 3,
+                        "players": [
+                            "U8THDCVJ7",
                             "UBA5M220K"
                         ]
                     }
@@ -388,7 +411,7 @@
         },
         "active_challenges": {},
         "completed_challenges": [],
-        "last_update_ts": 1572331168325,
+        "last_update_ts": 1572417581717,
         "reported_results": []
     }
 }

--- a/ranking-info/ranking.json
+++ b/ranking-info/ranking.json
@@ -233,9 +233,9 @@
             },
             "UB616ENA0": {
                 "initial_coins": 1,
-                "coins": 1,
+                "coins": 0,
                 "range": 2,
-                "points": 2052,
+                "points": 2042,
                 "completed_challenges": [
                     {
                         "winner": "UB616ENA0",
@@ -245,6 +245,17 @@
                         "player2Result": 3,
                         "players": [
                             "U8THDCVJ7",
+                            "UB616ENA0"
+                        ]
+                    },
+                    {
+                        "winner": "UMY200LSC",
+                        "player1": "UMY200LSC",
+                        "player2": "UB616ENA0",
+                        "player1Result": 3,
+                        "player2Result": 1,
+                        "players": [
+                            "UMY200LSC",
                             "UB616ENA0"
                         ]
                     }
@@ -268,15 +279,27 @@
                 "initial_coins": 2,
                 "coins": 2,
                 "range": 2,
-                "points": 1700,
+                "points": 1739,
                 "completed_challenges": []
             },
             "U8THDCVJ7": {
                 "initial_coins": 1,
-                "coins": 1,
+                "coins": 0,
                 "range": 1,
-                "points": 2100,
-                "completed_challenges": []
+                "points": 2092,
+                "completed_challenges": [
+                    {
+                        "winner": "UMY200LSC",
+                        "player1": "UMY200LSC",
+                        "player2": "U8THDCVJ7",
+                        "player1Result": 3,
+                        "player2Result": 1,
+                        "players": [
+                            "UMY200LSC",
+                            "U8THDCVJ7"
+                        ]
+                    }
+                ]
             },
             "U6457D5KQ": {
                 "initial_coins": 2,
@@ -287,9 +310,9 @@
             },
             "UBA5M220K": {
                 "initial_coins": 2,
-                "coins": 2,
-                "range": 4,
-                "points": 2184,
+                "coins": 0,
+                "range": 6,
+                "points": 2234,
                 "completed_challenges": [
                     {
                         "winner": "UBA5M220K",
@@ -311,6 +334,28 @@
                         "players": [
                             "U8THDCVJ7",
                             "UBA5M220K"
+                        ]
+                    },
+                    {
+                        "winner": "UBA5M220K",
+                        "player1": "UMY200LSC",
+                        "player2": "UBA5M220K",
+                        "player1Result": 1,
+                        "player2Result": 3,
+                        "players": [
+                            "UMY200LSC",
+                            "UBA5M220K"
+                        ]
+                    },
+                    {
+                        "winner": "UBA5M220K",
+                        "player1": "UBA5M220K",
+                        "player2": "UKPTK422K",
+                        "player1Result": 3,
+                        "player2Result": 2,
+                        "players": [
+                            "UBA5M220K",
+                            "UKPTK422K"
                         ]
                     }
                 ]
@@ -389,17 +434,41 @@
             },
             "UHHD243DH": {
                 "initial_coins": 3,
-                "coins": 3,
+                "coins": 2,
                 "range": 3,
-                "points": 1500,
-                "completed_challenges": []
+                "points": 1492,
+                "completed_challenges": [
+                    {
+                        "winner": "U8M6QT7EF",
+                        "player1": "UHHD243DH",
+                        "player2": "U8M6QT7EF",
+                        "player1Result": 1,
+                        "player2Result": 3,
+                        "players": [
+                            "UHHD243DH",
+                            "U8M6QT7EF"
+                        ]
+                    }
+                ]
             },
             "UMY200LSC": {
                 "initial_coins": 1,
                 "coins": 1,
-                "range": 1,
-                "points": 2200,
-                "completed_challenges": []
+                "range": 2,
+                "points": 2299,
+                "completed_challenges": [
+                    {
+                        "winner": "UMY200LSC",
+                        "player1": "UMY200LSC",
+                        "player2": "UKPTK422K",
+                        "player1Result": 3,
+                        "player2Result": 1,
+                        "players": [
+                            "UMY200LSC",
+                            "UKPTK422K"
+                        ]
+                    }
+                ]
             },
             "ULBS05D3M": {
                 "initial_coins": 2,
@@ -411,7 +480,7 @@
         },
         "active_challenges": {},
         "completed_challenges": [],
-        "last_update_ts": 1572417581717,
+        "last_update_ts": 1572504007283,
         "reported_results": []
     }
 }

--- a/ranking-info/ranking.json
+++ b/ranking-info/ranking.json
@@ -276,9 +276,21 @@
             "UBA5M220K": {
                 "initial_coins": 2,
                 "coins": 2,
-                "range": 2,
-                "points": 1900,
-                "completed_challenges": []
+                "range": 3,
+                "points": 2125,
+                "completed_challenges": [
+                    {
+                        "winner": "UBA5M220K",
+                        "player1": "UB616ENA0",
+                        "player2": "UBA5M220K",
+                        "player1Result": 0,
+                        "player2Result": 3,
+                        "players": [
+                            "UB616ENA0",
+                            "UBA5M220K"
+                        ]
+                    }
+                ]
             },
             "UAGR4S57G": {
                 "initial_coins": 4,
@@ -296,10 +308,33 @@
             },
             "UDR61HJCD": {
                 "initial_coins": 2,
-                "coins": 2,
+                "coins": 0,
                 "range": 2,
-                "points": 1800,
-                "completed_challenges": []
+                "points": 1785,
+                "completed_challenges": [
+                    {
+                        "winner": "UBA5M220K",
+                        "player1": "UDR61HJCD",
+                        "player2": "UBA5M220K",
+                        "player1Result": 0,
+                        "player2Result": 3,
+                        "players": [
+                            "UDR61HJCD",
+                            "UBA5M220K"
+                        ]
+                    },
+                    {
+                        "winner": "UBA5M220K",
+                        "player1": "UDR61HJCD",
+                        "player2": "UBA5M220K",
+                        "player1Result": 0,
+                        "player2Result": 3,
+                        "players": [
+                            "UDR61HJCD",
+                            "UBA5M220K"
+                        ]
+                    }
+                ]
             },
             "UBD38N45P": {
                 "initial_coins": 4,
@@ -353,7 +388,7 @@
         },
         "active_challenges": {},
         "completed_challenges": [],
-        "last_update_ts": 1572244755919,
+        "last_update_ts": 1572331168325,
         "reported_results": []
     }
 }

--- a/ranking-info/ranking.json
+++ b/ranking-info/ranking.json
@@ -1,12 +1,12 @@
 {
-    "last_update_ts": 1572235242373,
+    "last_update_ts": 1572244755919,
     "season": {
         "start": 1562511600001,
         "end": 1573142400001
     },
     "current_week": {
-        "start": 1571583600001,
-        "end": 1572188400000
+        "start": 1572188400001,
+        "end": 1572793200000
     },
     "ranking": [
         [
@@ -353,7 +353,7 @@
         },
         "active_challenges": {},
         "completed_challenges": [],
-        "last_update_ts": 1572235242373,
+        "last_update_ts": 1572244755919,
         "reported_results": []
     }
 }

--- a/src/smash-league.js
+++ b/src/smash-league.js
@@ -133,7 +133,7 @@ const applyPlayersUntieScoringRules = (winnerInSamePlaceScore, loserScore, winne
 
 const applyPlayerChallengedLosesScoringRules = (playerChallengedScore, challengerScore) => ({
     ...playerChallengedScore,
-    points: eloCalculation(challengerScore.points, playerChallengedScore.score, 1)
+    points: eloCalculation(challengerScore.points, playerChallengedScore.points, 0)
 })
 
 const updateInProgressScoreboard = (activities, rankingObj) => {

--- a/src/smash-league.js
+++ b/src/smash-league.js
@@ -131,6 +131,11 @@ const applyPlayersUntieScoringRules = (winnerInSamePlaceScore, loserScore, winne
     points: eloCalculation(winnerInSamePlaceScore.points, loserScore.points, winnerMatchScoreDiff)
 })
 
+const applyPlayerChallengedLosesScoringRules = (playerChallengedScore, challengerScore) => ({
+    ...playerChallengedScore,
+    points: eloCalculation(challengerScore.points, playerChallengedScore.score, 1)
+})
+
 const updateInProgressScoreboard = (activities, rankingObj) => {
 
     if (typeof activities !== 'object') {
@@ -191,6 +196,7 @@ const updateInProgressScoreboard = (activities, rankingObj) => {
             else {// Normal challenge
                 if (winner === challengerId) {
                     currentScoreboard[challengerId] = applyChallengerWinsScoringRules(challengerScore, playerChallengedScore, winnerMatchDiffResult)
+                    currentScoreboard[playerChallengedId] = applyPlayerChallengedLosesScoringRules(playerChallengedScore, challengerScore)
                     const playerWentToTheTop = (challengerPlace - currentScoreboard[challengerId].range) <= 0
                     if (playerWentToTheTop) {
                         // Player basically see the credits & waits to start over

--- a/src/tests/smash-league.test.constants.js
+++ b/src/tests/smash-league.test.constants.js
@@ -36,119 +36,119 @@ module.exports = {
     SCOREBOARD1: {
         "U8A96RCEA": {
             "initial_coins": 0,
-            "points": 3,
+            "points": 3000,
             "coins": 0,
             "range": 0,
             "completed_challenges": []
         },
         "U61MBQTR8": {
             "initial_coins": 0,
-            "points": 44,
+            "points": 4400,
             "coins": 1,
             "range": 1,
             "completed_challenges": []
         },
         "U7VAPLNCR": {
             "initial_coins": 0,
-            "points": 31,
+            "points": 3100,
             "coins": 0,
             "range": 0,
             "completed_challenges": []
         },
         "UBRMBGR6Z": {
             "initial_coins": 0,
-            "points": 29,
+            "points": 2900,
             "coins": 0,
             "range": 0,
             "completed_challenges": []
         },
         "UB616ENA0": {
             "initial_coins": 0,
-            "points": 40,
+            "points": 4000,
             "coins": 1,
             "range": 1,
             "completed_challenges": []
         },
         "UEWUZCYJF": {
             "initial_coins": 0,
-            "points": 18,
+            "points": 1800,
             "coins": 0,
             "range": 0,
             "completed_challenges": []
         },
         "UDBD59WLT": {
             "initial_coins": 0,
-            "points": 42,
+            "points": 4200,
             "coins": 0,
             "range": 0,
             "completed_challenges": []
         },
         "U8M6QT7EF": {
             "initial_coins": 0,
-            "points": 33,
+            "points": 3300,
             "coins": 0,
             "range": 0,
             "completed_challenges": []
         },
         "U87CK0E4A": {
             "initial_coins": 0,
-            "points": 27,
+            "points": 3691,
             "coins": 0,
             "range": 0,
             "completed_challenges": []
         },
         "U8THDCVJ7": {
             "initial_coins": 0,
-            "points": 36,
+            "points": 3600,
             "coins": 0,
             "range": 0,
             "completed_challenges": []
         },
         "U6457D5KQ": {
             "initial_coins": 0,
-            "points": 37,
+            "points": 3700,
             "coins": 2,
             "range": 2,
             "completed_challenges": []
         },
         "UBA5M220K": {
             "initial_coins": 0,
-            "points": 37,
+            "points": 3700,
             "coins": 1,
             "range": 1,
             "completed_challenges": []
         },
         "UAGR4S57G": {
             "initial_coins": 0,
-            "points": 16,
+            "points": 983,
             "coins": 0,
             "range": 0,
             "completed_challenges": []
         },
         "UBRCZ6G4B": {
             "initial_coins": 0,
-            "points": 3,
+            "points": 1300,
             "coins": 0,
             "range": 0,
             "completed_challenges": []
         },
         "UDR61HJCD": {
             "initial_coins": 0,
-            "points": 27,
+            "points": 2700,
             "coins": 0,
             "range": 0,
             "completed_challenges": []
         },
         "UBD38N45P": {
             "initial_coins": 0,
-            "points": 10,
+            "points": 1000,
             "coins": 0,
             "range": 0,
             "completed_challenges": []
         },
         "U6H8DDV25": {
             "initial_coins": 0,
-            "points": 9,
+            "points": 1900,
             "coins": 0,
             "range": 0,
             "completed_challenges": []
@@ -178,14 +178,14 @@ module.exports = {
             "scoreboard": {
                 "UDR61HJCD": {
                     "initial_coins": 2,
-                    "points": 27,
+                    "points": 2700,
                     "coins": 0,
                     "range": 6,
                     "completed_challenges": []
                 },
                 "U8A96RCEA": {
                     "initial_coins": 3,
-                    "points": 3,
+                    "points": 1300,
                     "coins": 0,
                     "range": 3,
                     "completed_challenges": [
@@ -201,7 +201,7 @@ module.exports = {
                 },
                 "U61MBQTR8": {
                     "initial_coins": 0,
-                    "points": 44,
+                    "points": 4400,
                     "coins": 0,
                     "range": 0,
                     "completed_challenges": [
@@ -213,7 +213,7 @@ module.exports = {
                 },
                 "U7VAPLNCR": {
                     "initial_coins": 1,
-                    "points": 43,
+                    "points": 4300,
                     "coins": 1,
                     "range": 2,
                     "completed_challenges": [
@@ -225,7 +225,7 @@ module.exports = {
                 },
                 "UBRMBGR6Z": {
                     "initial_coins": 2,
-                    "points": 29,
+                    "points": 2900,
                     "coins": 1,
                     "range": 4,
                     "completed_challenges": []
@@ -256,35 +256,35 @@ module.exports = {
             "scoreboard": {
                 "U8A96RCEA": {
                     "initial_coins": 1,
-                    "points": 3,
+                    "points": 1300,
                     "coins": 1,
                     "range": 1,
                     "completed_challenges": []
                 },
                 "U61MBQTR8": {
                     "initial_coins": 0,
-                    "points": 44,
+                    "points": 4400,
                     "coins": 0,
                     "range": 0,
                     "completed_challenges": []
                 },
                 "U7VAPLNCR": {
                     "initial_coins": 1,
-                    "points": 43,
+                    "points": 4300,
                     "coins": 1,
                     "range": 1,
                     "completed_challenges": []
                 },
                 "UBRMBGR6Z": {
                     "initial_coins": 1,
-                    "points": 29,
+                    "points": 2900,
                     "coins": 1,
                     "range": 1,
                     "completed_challenges": []
                 },
                 "UDR61HJCD": {
                     "initial_coins": 1,
-                    "points": 27,
+                    "points": 2700,
                     "coins": 1,
                     "range": 1,
                     "completed_challenges": []

--- a/src/tests/smash-league.test.js
+++ b/src/tests/smash-league.test.js
@@ -55,7 +55,7 @@ describe('Smash League Challenges & Scoreboard', () => {
             ...SCOREBOARD1,
             "U6457D5KQ": {
                 "initial_coins": 0,
-                "points": 22,
+                "points": 3690,
                 "coins": 0,
                 "range": 3,
                 "completed_challenges": [
@@ -64,42 +64,42 @@ describe('Smash League Challenges & Scoreboard', () => {
             },
             "UBA5M220K": {
                 "initial_coins": 0,
-                "points": 235,
+                "points": 3807,
                 "coins": 1,
                 "range": 1,
                 "completed_challenges": []
             },
             "U61MBQTR8": {
                 "initial_coins": 0,
-                "points": 91,
+                "points": 4419,
                 "coins": 0,
                 "range": 2,
                 "completed_challenges": [ ACTIVITIES1[10] ]
             },
             "UB616ENA0": {
                 "initial_coins": 0,
-                "points": 29,
+                "points": 3987,
                 "coins": 0,
                 "range": 1,
                 "completed_challenges": [ ACTIVITIES1[5] ]
             },
             "UDBD59WLT": {
                 "initial_coins": 0,
-                "points": 42,
+                "points": 4387,
                 "coins": 0,
                 "range": 0,
                 "completed_challenges": []
             },
             "newPlayer": {
                 "initial_coins": 3,
-                "points": 936,
+                "points": 1013,
                 "coins": 1,
                 "range": 4,
                 "completed_challenges": [ ACTIVITIES1[7], ACTIVITIES1[8], ACTIVITIES1[9] ]
             },
             "U7VAPLNCR": {
                 "initial_coins": 0,
-                "points": 157,
+                "points": 3132,
                 "coins": 0,
                 "range": 0,
                 "completed_challenges": []


### PR DESCRIPTION
## What does this do?
In this PR, we added the corresponding behavior to be used when the challenged player loses the match and loses points.

## How can this change be undone in case of failure?

1. Notify the administrators
2. Request a revert of the PR


ping @Xotl
