### PR TITLE
Inactivity feature

### DIFF
--- a/RANKING-template.md
+++ b/RANKING-template.md
@@ -8,6 +8,8 @@ Unranked players and players that have 0 points will start with this score:
 
 {{unranked_score}}
 
+{{inactive_players}}
+
 ## In progress this week *{{inprogress_last_updated}}*
 This section shows the progress of the week. Every sunday the below categories will be reseted and the Ranking will get updated.
 

--- a/ranking-info/README.md
+++ b/ranking-info/README.md
@@ -1,6 +1,6 @@
 # Ranking
 
-Last updated **Sun, 03 Nov 2019 19:52:41 GMT**.
+Last updated **Mon, 04 Nov 2019 01:14:27 GMT**.
 
 |#|Player|Score|
 |-|------|-----|
@@ -19,8 +19,8 @@ Last updated **Sun, 03 Nov 2019 19:52:41 GMT**.
 |13|`Alan`, `Paolo`|1480|
 |14|`Niightz`|1470|
 |15|`Michel`|1440|
-|16|`Medininja`|1420|
-|17|`Carlos López`, `David`|1000|
+|16|`UKB40CVF0`|1093|
+|17|`Medininja`|997|
 
 Unranked players and players that have 0 points will start with this score:
 
@@ -28,7 +28,18 @@ Unranked players and players that have 0 points will start with this score:
 |-----|-----|------|
 |4|4|1000|
 
-## In progress this week *Sun, 03 Nov 2019 19:52:41 GMT*
+### Inactive players
+* Carlos López - Deleted this week after 4 week(s).
+* Alan - 1 week(s) inactive.
+* El Chino - 1 week(s) inactive.
+* César Gutman - Deleted this week after 1 week(s).
+* D.I.O. - 1 week(s) inactive.
+* Michel - 1 week(s) inactive.
+* Niightz - 1 week(s) inactive.
+* David - Deleted this week after 1 week(s).
+* El Plebe - 1 week(s) inactive.
+
+## In progress this week *Mon, 04 Nov 2019 01:14:27 GMT*
 This section shows the progress of the week. Every sunday the below categories will be reseted and the Ranking will get updated.
 
 ### Current Scoreboard
@@ -52,10 +63,8 @@ The current points earned by winning matches this week.
 |Paolo|3|3|1480|
 |Niightz|3|3|1470|
 |Michel|3|3|1440|
-|Medininja|4|4|1420|
-|Carlos López|4|4|1000|
-|David|4|4|1000|
-|César Gutman|4|4|0|
+|UKB40CVF0|4|4|1093|
+|Medininja|4|4|997|
 
 ### Completed challenges
 Matches that already happened during this week.

--- a/ranking-info/history-log.md
+++ b/ranking-info/history-log.md
@@ -1,3 +1,58 @@
+## Commit from Mon, 04 Nov 2019 01:14:27 GMT
+The week started at *Sun, 27 Oct 2019 15:00:00 GMT* and ended *Sun, 03 Nov 2019 15:00:00 GMT*.
+### End of week players score summary
+|Player|Coins|Range|
+|------|-----|-----|
+|José "El Iceberg" Rosales - 2290pts|1|7|
+|Roberto - 2258pts|0|2|
+|Xotl - 2218pts|0|0|
+|Paco - 2201pts|0|1|
+|Angel Lee - 1938pts|0|2|
+|Neku - 1876pts|0|1|
+|Sammy - 1785pts|0|2|
+|El Minion - 1739pts|2|2|
+|Alfredo - 1643pts|2|2|
+|D.I.O. - 1510pts|2|2|
+|El Chino - 1495pts|3|3|
+|El Plebe - 1490pts|3|3|
+|Alan - 1480pts|3|3|
+|Paolo - 1480pts|1|3|
+|Niightz - 1470pts|3|3|
+|Michel - 1440pts|4|4|
+|UKB40CVF0 - 1093pts|4|5|
+|Carlos López - 1000pts|4|4|
+|David - 1000pts|4|4|
+|Medininja - 997pts|4|4|
+|César Gutman - 0pts|4|4|
+### Completed challenges
+* `Angel Lee` challenged `Neku` and **won** *3-1*.
+* `Angel Lee` challenged `Roberto` and **lost** *3-1*.
+* `Neku` challenged `Roberto` and **lost** *3-1*.
+* `José "El Iceberg" Rosales` challenged `Angel Lee` and **won** *3-0*.
+* `José "El Iceberg" Rosales` challenged `Neku` and **won** *3-0*.
+* `José "El Iceberg" Rosales` challenged `Roberto` and **won** *3-1*.
+* `José "El Iceberg" Rosales` challenged `Paco` and **won** *3-2*.
+* `José "El Iceberg" Rosales` challenged `Xotl` and **lost** *3-1*.
+* `José "El Iceberg" Rosales` challenged `Xotl` and **won** *3-0*.
+* `Sammy` challenged `José "El Iceberg" Rosales` and **lost** *3-0*.
+* `Sammy` challenged `José "El Iceberg" Rosales` and **lost** *3-0*.
+* `Paco` challenged `Xotl` and **lost** *3-2*.
+* `Paolo` challenged `El Minion` and **lost** *3-1*.
+* `Paolo` challenged `Alfredo` and **lost** *3-1*.
+* `Roberto` challenged `Paco` and **won** *3-1*.
+* `Roberto` challenged `Xotl` and **lost** *3-2*.
+* `UKB40CVF0` challenged `Medininja` and **won** *3-0*.
+### Inactive players
+* Carlos López - Deleted this week after 4 week(s).
+* Alan - 1 week(s) inactive.
+* El Chino - 1 week(s) inactive.
+* César Gutman - Deleted this week after 1 week(s).
+* D.I.O. - 1 week(s) inactive.
+* Michel - 1 week(s) inactive.
+* Niightz - 1 week(s) inactive.
+* David - Deleted this week after 1 week(s).
+* El Plebe - 1 week(s) inactive.
+
 ## Commit from Sun, 03 Nov 2019 19:52:41 GMT
 The week started at *Sun, 27 Oct 2019 15:00:00 GMT* and ended *Sun, 03 Nov 2019 15:00:00 GMT*.
 ### End of week players score summary

--- a/ranking-info/ranking.json
+++ b/ranking-info/ranking.json
@@ -1,5 +1,5 @@
 {
-    "last_update_ts": 1572810761549,
+    "last_update_ts": 1572830067930,
     "season": {
         "start": 1562511600001,
         "end": 1573142400001
@@ -56,21 +56,13 @@
             "UAGR4S57G"
         ],
         [
-            "U6H8DDV25"
+            "UKB40CVF0"
         ],
         [
-            "U8A96RCEA",
-            "UBD38N45P"
+            "U6H8DDV25"
         ]
     ],
     "scoreboard": {
-        "U8A96RCEA": {
-            "initial_coins": 4,
-            "coins": 4,
-            "range": 4,
-            "points": 1000,
-            "completed_challenges": []
-        },
         "U61MBQTR8": {
             "initial_coins": 0,
             "coins": 0,
@@ -120,13 +112,6 @@
             "coins": 3,
             "range": 3,
             "points": 1495,
-            "completed_challenges": []
-        },
-        "UDBD59WLT": {
-            "initial_coins": 4,
-            "coins": 4,
-            "range": 4,
-            "points": 0,
             "completed_challenges": []
         },
         "U8M6QT7EF": {
@@ -280,18 +265,11 @@
                 }
             ]
         },
-        "UBD38N45P": {
-            "initial_coins": 4,
-            "coins": 4,
-            "range": 4,
-            "points": 1000,
-            "completed_challenges": []
-        },
         "U6H8DDV25": {
             "initial_coins": 4,
             "coins": 4,
             "range": 4,
-            "points": 1420,
+            "points": 997,
             "completed_challenges": []
         },
         "UHM2TH85S": {
@@ -386,18 +364,30 @@
             "range": 2,
             "points": 1643,
             "completed_challenges": []
+        },
+        "UKB40CVF0": {
+            "points": 1093,
+            "initial_coins": 4,
+            "coins": 4,
+            "range": 5,
+            "completed_challenges": [
+                {
+                    "winner": "UKB40CVF0",
+                    "player1": "UKB40CVF0",
+                    "player2": "U6H8DDV25",
+                    "player1Result": 3,
+                    "player2Result": 0,
+                    "players": [
+                        "UKB40CVF0",
+                        "U6H8DDV25"
+                    ]
+                }
+            ]
         }
     },
     "unknown_users": [],
     "in_progress": {
         "scoreboard": {
-            "U8A96RCEA": {
-                "initial_coins": 4,
-                "coins": 4,
-                "range": 4,
-                "points": 1000,
-                "completed_challenges": []
-            },
             "U61MBQTR8": {
                 "initial_coins": 1,
                 "coins": 1,
@@ -424,13 +414,6 @@
                 "coins": 3,
                 "range": 3,
                 "points": 1495,
-                "completed_challenges": []
-            },
-            "UDBD59WLT": {
-                "initial_coins": 4,
-                "coins": 4,
-                "range": 4,
-                "points": 0,
                 "completed_challenges": []
             },
             "U8M6QT7EF": {
@@ -482,18 +465,11 @@
                 "points": 1785,
                 "completed_challenges": []
             },
-            "UBD38N45P": {
-                "initial_coins": 4,
-                "coins": 4,
-                "range": 4,
-                "points": 1000,
-                "completed_challenges": []
-            },
             "U6H8DDV25": {
                 "initial_coins": 4,
                 "coins": 4,
                 "range": 4,
-                "points": 1420,
+                "points": 997,
                 "completed_challenges": []
             },
             "UHM2TH85S": {
@@ -530,11 +506,59 @@
                 "range": 2,
                 "points": 1643,
                 "completed_challenges": []
+            },
+            "UKB40CVF0": {
+                "initial_coins": 4,
+                "coins": 4,
+                "range": 4,
+                "points": 1093,
+                "completed_challenges": []
             }
         },
         "active_challenges": {},
         "completed_challenges": [],
-        "last_update_ts": 1572810761549,
+        "last_update_ts": 1572830067930,
         "reported_results": []
+    },
+    "inactive_players": {
+        "U8A96RCEA": {
+            "weeks_count": 4,
+            "inactive_since": 1572810761549,
+            "deleted_by_inactivity": true
+        },
+        "UBRMBGR6Z": {
+            "weeks_count": 1,
+            "inactive_since": 1572830067930
+        },
+        "UEWUZCYJF": {
+            "weeks_count": 1,
+            "inactive_since": 1572830067930
+        },
+        "UDBD59WLT": {
+            "weeks_count": 1,
+            "inactive_since": 1572830067930,
+            "deleted_by_inactivity": true
+        },
+        "U6457D5KQ": {
+            "weeks_count": 1,
+            "inactive_since": 1572830067930
+        },
+        "UAGR4S57G": {
+            "weeks_count": 1,
+            "inactive_since": 1572830067930
+        },
+        "UBRCZ6G4B": {
+            "weeks_count": 1,
+            "inactive_since": 1572830067930
+        },
+        "UBD38N45P": {
+            "weeks_count": 1,
+            "inactive_since": 1572830067930,
+            "deleted_by_inactivity": true
+        },
+        "UHM2TH85S": {
+            "weeks_count": 1,
+            "inactive_since": 1572830067930
+        }
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,9 @@ async function Main() {
 
     if (isItTimeToCommit) {
         newRankingObj = SmashLeague.commitInProgress(newRankingObj)
-        OutputGenerator.updateHistoryLog(newInProgressObj, newRankingObj.current_week)
+        OutputGenerator.updateHistoryLog(
+            newInProgressObj, newRankingObj.current_week, newRankingObj.inactive_players
+        )
     }
 
     await OutputGenerator.updateRankingJsonFile(newRankingObj)

--- a/src/tests/output-generator.test.constants.js
+++ b/src/tests/output-generator.test.constants.js
@@ -305,6 +305,17 @@ module.exports = {
             "completed_challenges": [],
             "last_update_ts": 1554012202785,
             "reported_results": []
+        },
+        "inactive_players": {
+            "U8A96RCEA": {
+                "weeks_count": 4,
+                "inactive_since": 1572810761549,
+                "deleted_by_inactivity": true
+            },
+            "UBRMBGR6Z": {
+                "weeks_count": 1,
+                "inactive_since": 1572830067930
+            }
         }
     }
 }

--- a/src/tests/output-generator.test.js
+++ b/src/tests/output-generator.test.js
@@ -43,7 +43,7 @@ describe('Utils', () => {
         const closeSyncFnSpy = jest.spyOn(fs, 'closeSync').mockImplementation(jest.fn())
 
         expect.assertions(3);
-        await expect( updateHistoryLog(RANKING_OBJ1.in_progress, RANKING_OBJ1.current_week) ).resolves.not.toThrow()
+        await expect( updateHistoryLog(RANKING_OBJ1.in_progress, RANKING_OBJ1.current_week, {}) ).resolves.not.toThrow()
         expect( writeSyncFnSpy ).toHaveBeenCalledTimes(2)
         expect( closeSyncFnSpy ).toHaveBeenCalledTimes(1)
     })

--- a/src/tests/smash-league.test.constants.js
+++ b/src/tests/smash-league.test.constants.js
@@ -228,7 +228,12 @@ module.exports = {
                     "points": 2900,
                     "coins": 1,
                     "range": 4,
-                    "completed_challenges": []
+                    "completed_challenges": [
+                        // Adding some data for inactivity test
+                        { player1: "U8A96RCEA", player2: "U61MBQTR8"},
+                        { player1: "U7VAPLNCR", player2: "UBRMBGR6Z"},
+                        { player1: "UBRMBGR6Z", player2: "U61MBQTR8"},
+                    ]
                 }
             },
             "last_update_ts": 1556470800000
@@ -291,6 +296,12 @@ module.exports = {
                 }
             },
             "last_update_ts": 1556470800000
+        },
+        "inactive_players": {
+            "UDR61HJCD": {
+                inactive_since: 1556470800000,
+                weeks_count: 1
+            } 
         }
     },
 


### PR DESCRIPTION
## What does this do?
Now inactive players will be punished after one week, and if they end up below 1000 ELO they're removed from ranking.
Also the ranking README file includes info about inactive players.

## How can this change be undone in case of failure?

1. Notify the administrators
2. Request a revert of the PR


ping @Xotl
