### PR TITLE
Add messages for a new champion

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ async function Main() {
     const newChampion = Utils.aNewChampion(Ranking.ranking, newRankingObj.ranking)
 
     const blocksToPost = SmashLeagueInteractions.getUpdatesToNotifyUsers(
-        isItTimeToCommit ? {/* TODO: send weeks times */} : null,
+        isItTimeToCommit ? { newChampion } : null,
         activities.reportedResults.length,
         ignoredActivities, 
         activities.ignoredMessages.length,

--- a/src/index.js
+++ b/src/index.js
@@ -64,8 +64,7 @@ async function Main() {
         ignoredActivities, 
         activities.ignoredMessages.length,
         newRankingObj.season,
-        IS_UPDATE ? version : null,
-        newChampion
+        IS_UPDATE ? version : null
     )
         
     // Only post in slack if it's a master Job

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,7 @@ async function Main() {
         SmashLeague.getUnrankedPlayerScore(newRankingObj.ranking.length)
     )
 
+    const newChampion = Utils.aNewChampion(Ranking.ranking, newRankingObj.ranking)
 
     const blocksToPost = SmashLeagueInteractions.getUpdatesToNotifyUsers(
         isItTimeToCommit ? {/* TODO: send weeks times */} : null,
@@ -63,7 +64,8 @@ async function Main() {
         ignoredActivities, 
         activities.ignoredMessages.length,
         newRankingObj.season,
-        IS_UPDATE ? version : null
+        IS_UPDATE ? version : null,
+        newChampion
     )
         
     // Only post in slack if it's a master Job

--- a/src/messages.js
+++ b/src/messages.js
@@ -201,7 +201,12 @@ module.exports = Tag => ({
     "daily_update week_commited": [
         "¡Ha iniciando un nuevo ranking esta semana!, ya <https://github.com/Xotl/Smash-League/tree/master/ranking-info/README.md|pueden revisar> en qué lugar quedaron.",
         "¡Nueva semana! <https://github.com/Xotl/Smash-League/tree/master/ranking-info/README.md|pueden revisar> en qué lugar quedaron.",
-        "<https://github.com/Xotl/Smash-League/tree/master/ranking-info/README.md|Pueden revisar> en qué lugar quedaron. ¡Ha iniciado otra semans de la liga!.",
+        "<https://github.com/Xotl/Smash-League/tree/master/ranking-info/README.md|Pueden revisar> en qué lugar quedaron. ¡Ha iniciado otra semana de la liga!.",
+    ],
+    "daily_update week_commited_new_champion": [
+        ({ newChampionName }) => `Contra todo pronostico, ¡${newChampionName} se corona como el nuevo campeón de la liga! :crown:`,
+        ({ newChampionName }) => `¿Pero qué demonios esta pasando? ¿${newChampionName} quedando primero? ¿Qué sigue? ¿Tiburosos voladores de papantla? :bearboss:`,
+        ({ newChampionName }) => `Y como nuevo campeón de la liga ha quedado ${newChampionName}, nada fuera de lo esperado... ¿Verdad? ¡¿Verdad?! :sweat_smile:`
     ],
     "daily_update ignored_activities": [
         ({numIgnoredActivities, ignoredMessages}) => "Además, parece que aún hay gente que no conoce las reglas, ya que tuve que ignorar " + 

--- a/src/smash-league-interactions.js
+++ b/src/smash-league-interactions.js
@@ -320,7 +320,7 @@ const categorizeSlackMessages = async (messagesArray) => {
 }
 
 const getUpdatesToNotifyUsers = (weekCommited, totalValidActivities, ignoredActivities, 
-    ignoredMessagesCount, season, newVersion, newChampionName) => {
+    ignoredMessagesCount, season, newVersion) => {
 
     const slackBlocks = []
     if (newVersion) {
@@ -392,7 +392,7 @@ const getUpdatesToNotifyUsers = (weekCommited, totalValidActivities, ignoredActi
         ])
     }
 
-    if (newChampionName) {
+    if (weekCommited.newChampionName) {
         slackBlocks.push([
             {
                 "type": "section",

--- a/src/smash-league-interactions.js
+++ b/src/smash-league-interactions.js
@@ -320,7 +320,7 @@ const categorizeSlackMessages = async (messagesArray) => {
 }
 
 const getUpdatesToNotifyUsers = (weekCommited, totalValidActivities, ignoredActivities, 
-    ignoredMessagesCount, season, newVersion) => {
+    ignoredMessagesCount, season, newVersion, newChampionName) => {
 
     const slackBlocks = []
     if (newVersion) {
@@ -387,6 +387,18 @@ const getUpdatesToNotifyUsers = (weekCommited, totalValidActivities, ignoredActi
                 "text": {
                     "type": "mrkdwn",
                     "text": Utils.getRandomMessageById('daily_update week_commited')
+                }
+            }
+        ])
+    }
+
+    if (newChampionName) {
+        slackBlocks.push([
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": Utils.getRandomMessageById('daily_update week_commited_new_champion', { newChampionName })
                 }
             }
         ])

--- a/src/utils.js
+++ b/src/utils.js
@@ -129,7 +129,7 @@ const eloCalculation = (playerAElo, playerBElo, playerAScore) => {
  */
 const aNewChampion = (oldRank, newRank) => {
     if (oldRank[0][0] !== newRank[0][0]) {
-        return Config.users_dict[newRank[0][0]]
+        return getPlayerAlias(newRank[0][0])
     }
 
     return false

--- a/src/utils.js
+++ b/src/utils.js
@@ -120,6 +120,21 @@ const eloCalculation = (playerAElo, playerBElo, playerAScore) => {
     return Math.trunc(playerAElo + factorKCaculator(playerAElo) * (playerAScore - probabilityOfWinPlayerA))
 }
 
+/**
+ * 
+ * @param {Array} oldRank Contains the old ranking
+ * @param {Array} newRank Contains the new ranking
+ *
+ * @returns {(boolean|string)} If there is a new champion, returns the name, if not, false.
+ */
+const aNewChampion = (oldRank, newRank) => {
+    if (oldRank[0][0] !== newRank[0][0]) {
+        return Config.users_dict[newRank[0][0]]
+    }
+
+    return false
+}
+
 module.exports = {
     GetDateObjFromEpochTS,
     GetEpochUnixFromDate,
@@ -134,4 +149,5 @@ module.exports = {
     removeAlreadyChallengedPlayers,
     removeEmptyArray,
     eloCalculation,
+    aNewChampion
 }


### PR DESCRIPTION
## What does this do?
Added the logic used to get if there's a new champion in the league. also, added a set of new messages for when this happens. The messages are:
- Contra todo pronostico, ¡Fulano se corona como el nuevo campeón de la liga! :crown:
- ¿Pero qué demonios esta pasando? ¿Zutano quedando primero? ¿Qué sigue? ¿Tiburosos voladores de papantla? :bearboss:
- Y como nuevo campeón de la liga ha quedado Mengano, nada fuera de lo esperado... ¿Verdad? ¡¿Verdad?! :sweat_smile:

Also, we fixed a typo on the `daily_update week_commited` messages.

## How can this change be undone in case of failure?

1. Notify the administrators
2. Request a revert of the PR


ping @Xotl
