### PR TITLE
Improvements

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -3,7 +3,7 @@ name: 'Smash League | Update'
 on:
   push: 
     branches: 
-    - master
+      - master
 
 jobs:
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,6 +1,9 @@
 name: 'Smash League | Update'
 
-on: push
+on:
+  push: 
+    branches: 
+    - master
 
 jobs:
 

--- a/config.json
+++ b/config.json
@@ -6,6 +6,10 @@
         "timeZone": "America/Mexico_City",
         "locale": "en-US"
     },
+    "admin_users": [
+        "U61MBQTR8", 
+        "U6457D5KQ"
+    ],
     "users_dict": {
         "U8A96RCEA": "Carlos López",
         "U61MBQTR8": "Xotl",

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,9 @@ async function Main() {
     const lastInProgressUpdated = new Date(Ranking.in_progress.last_update_ts + 1)
     const opts = { latest: now, oldest: lastInProgressUpdated }
     const slackResponse = await Slack.getMessagesFromPrivateChannel(SMASH_SLACK_CHANNEL_ID, opts)
-    const activities = await SmashLeagueInteractions.categorizeSlackMessages(slackResponse.messages)
+    const activities = await SmashLeagueInteractions.categorizeSlackMessages(
+        slackResponse.messages, Config.admin_users
+    )
     
     // We create & set the Object that will have all the data of the 
     // ignored activites logged by "logIgnoredActivity" function

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -4,6 +4,8 @@ const Config = require('../../config.json')
 const SmashLeagueInteractions = require('../smash-league-interactions')
 const Slack = require('../slack-api')
 const Utils = require('../utils')
+const Ranking = require('../../ranking-info/ranking.json')
+
 
 const WitClient = new Wit({
     accessToken: process.env.WIT_TOKEN,
@@ -52,7 +54,7 @@ const digetsWitReponseFromSlackEvent = async (slackEvent = {}) => {
 
     if (entities.lookup_challengers) {
         validIntentDetected = true
-        const res = SmashLeagueInteractions.getLookupChallengersResponseFromWitEntities(slackEvent.user, entities)
+        const res = SmashLeagueInteractions.getLookupChallengersResponseFromWitEntities(slackEvent.user, entities, Ranking)
         messagesToPost.push(
             ...getSlackMessagesObjFromInteractions(
                 res,

--- a/src/smash-league-interactions.js
+++ b/src/smash-league-interactions.js
@@ -4,7 +4,6 @@ const Utils = require('./utils')
 const SmashLeague = require('./smash-league')
 
 const Config = require('../config.json')
-const Ranking = require('../ranking-info/ranking.json')
 
 const WIT_TOKEN =  process.env.WIT_TOKEN
 const BOT_SLACK_TAG = `<@${Config.bot_id}>`
@@ -70,7 +69,7 @@ const getReportedResultObjFromWitEntities = (user, players = [], score = [], mat
     }
 }
 
-const getLookupChallengersResponseFromWitEntities = (user, witEntities) => {
+const getLookupChallengersResponseFromWitEntities = (user, witEntities, Ranking) => {
     const results = []
     witEntities.lookup_challengers.forEach(
         entity => {

--- a/src/smash-league-interactions.js
+++ b/src/smash-league-interactions.js
@@ -433,7 +433,7 @@ const getUpdatesToNotifyUsers = (weekCommited, totalValidActivities, ignoredActi
         }
     }
 
-    if (Array.isArray(ignoredActivities) && ignoredActivities.length > 0) {
+    if (ignoredActivities) {
         const ignoredMessages = Object.keys(ignoredActivities).map(
             type => {
                 ignoredActivities[type].map(

--- a/src/smash-league-interactions.js
+++ b/src/smash-league-interactions.js
@@ -8,6 +8,7 @@ const Ranking = require('../ranking-info/ranking.json')
 
 const WIT_TOKEN =  process.env.WIT_TOKEN
 const BOT_SLACK_TAG = `<@${Config.bot_id}>`
+const INVALID_MSG_REACTION_NAME = 'no_entry'
 
 const GetUserIDFromUserTag = userTag => userTag.slice(2, -1)
 
@@ -244,7 +245,7 @@ const getReportedResultFromWitEntities = (user, witEntities) => {
     return results
 }
 
-const categorizeSlackMessages = async (messagesArray) => {
+const categorizeSlackMessages = async (messagesArray, adminUsers) => {
     if (!Array.isArray(messagesArray)) {
         throw new Error('The argument messagesArray must be an Array.')
     }
@@ -256,8 +257,37 @@ const categorizeSlackMessages = async (messagesArray) => {
 
     const ignoredMessages = []
     const promiseArray = messagesArray.filter(
-        // Ignore it if Slack bot is not tagged in this message or is bot message
-        ({ text, subtype }) => !(subtype === 'bot_message' || -1 === text.indexOf(BOT_SLACK_TAG))
+        ({ user, text, subtype, reactions}) => {
+            // Ignore it if Slack bot is not tagged in this message or is bot message
+            if (subtype === 'bot_message' || -1 === text.indexOf(BOT_SLACK_TAG)) {
+                return false
+            }
+
+            if (!reactions) {// No reactions to check if the message got invalidated 
+                return true
+            }
+
+            const gotInvalidatedByAdmin = reactions.find(
+                ({ name, users }) => {
+                    if ( INVALID_MSG_REACTION_NAME !== name ) {
+                        // These are not the Droids you are looking for...
+                        return false
+                    }
+
+                    // Check if an admin invalidated this message
+                    return adminUsers.find(
+                        admin => users.includes(admin)
+                    )
+                }
+            )
+
+            if (gotInvalidatedByAdmin) {// Message invalidated by an admin
+                ignoredMessages.push(`Invalidated by Admin | [${Utils.getPlayerAlias(user)}] - ${text}`)
+                return false
+            }
+
+            return true
+        }
     ).map(
         async ({ text:message, user, ts, thread_ts }) => {
             const messageWithoutBotTag = Utils.removesBotTagFromString(message)
@@ -458,6 +488,8 @@ const notifyInThreadThatMeesagesGotIgnored = async (ignoredMessagesArray, postMe
         await postMessageFn(msg, Config.slack_channel_id, { thread_ts: thread_ts || ts })
     }
 }
+
+
 
 module.exports = {
     categorizeSlackMessages,

--- a/src/tests/smash-league-interactions.test.constants.js
+++ b/src/tests/smash-league-interactions.test.constants.js
@@ -99,15 +99,29 @@ module.exports = {
             "user": "U8A96RCEA",
             "ts": 2
         },
-        {
+        {// invalidated by administrator
+            "text": "<@UFY8P0WRF> le gané a <@UDBD59WLT> 3 - 0",
+            "user": "U8A96RCEA",
+            "ts": 2,
+            "reactions": [
+                { name: "no_entry", users: [ "admin_user1" ] }
+            ]
+        },
+        {// Ignored, but not invalidated by admin
             "text": "<@UFY8P0WRF> El viento de las gardenias toca la puerta 3 veces",
             "user": "U6H8DDV25",
-            "ts": 6
+            "ts": 6,
+            "reactions": [
+                { name: "fast_parrot", users: [ "admin_user1" ] }
+            ]
         },
         {// Valid spaces only on one side of result
             "text": "<@UFY8P0WRF> <@UB616ENA0> 2 - 3 <@U6457D5KQ>",
             "user": "UEWUZCYJF",
-            "ts": 1
+            "ts": 1,
+            "reactions": [
+                { name: "no_entry", users: [ "non_admin_user" ] }
+            ]
         },
         {// Valid, spaces both sides of result
             "text": "<@UFY8P0WRF> le gané a <@UDBD59WLT> 3 - 0",

--- a/src/tests/smash-league-interactions.test.js
+++ b/src/tests/smash-league-interactions.test.js
@@ -17,6 +17,9 @@ describe('Smash League interactions', () => {
     } )
 
     test('categorizeSlackMessages', async () => {
+        const logFnSpy = jest.spyOn(console, 'log')
+                            .mockImplementation(_ => { return })// NoOp
+
         const WitLib = require('node-wit')
         const witFnSpy = jest.spyOn(WitLib, 'Wit').mockImplementation( function () {
             return { message: messageMockFn }
@@ -34,7 +37,7 @@ describe('Smash League interactions', () => {
         expect(witFnSpy).not.toHaveBeenCalled()
 
         await expect(
-            categorizeSlackMessages(SLACK_MESSAGES1)
+            categorizeSlackMessages(SLACK_MESSAGES1, [ "admin_user1" ])
         ).resolves.toEqual({
             ignoredMessages: [ ],
             challenges: [],
@@ -59,6 +62,10 @@ describe('Smash League interactions', () => {
                 }
             ]
         })
+
+        expect(logFnSpy).toHaveBeenCalled()
+
+        logFnSpy.mockRestore()
         witFnSpy.mockRestore()
     })
 })


### PR DESCRIPTION
## What does this do?
* Adds administrator users.
* Adds a new functionality that allows administrators to invalidate messages.
* Removes the use of `ranking.json` file inside `smash-league-interactions.js`.
* Now `update.yml` workflow only runs on `master` branch.
* Now ignored activities should be posted in Slack.

## Picture / GIF of the solution
![image](https://user-images.githubusercontent.com/7025727/69019711-69dbeb80-0977-11ea-8d26-80d986c684fb.png)

## How can this change be undone in case of failure?

1. Notify the administrators
2. Request a revert of the PR


ping @Xotl
