### PR TITLE
Changing inactivity logic & small fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const IS_CI = process.env.CI
 
 
 async function Main() {
-    const today = new Date()
+    const today = new Date(1576479600000)
     const isItTimeToCommit = SmashLeague.isItTimeToCommitInProgress(today, Ranking.current_week)
     
     let now = today
@@ -32,6 +32,7 @@ async function Main() {
 
     // Next milisecond after last update because it's inclusive search
     const lastInProgressUpdated = new Date(Ranking.in_progress.last_update_ts + 1)
+    
     const opts = { latest: now, oldest: lastInProgressUpdated }
     const slackResponse = await Slack.getMessagesFromPrivateChannel(SMASH_SLACK_CHANNEL_ID, opts)
     const activities = await SmashLeagueInteractions.categorizeSlackMessages(

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const IS_CI = process.env.CI
 
 
 async function Main() {
-    const today = new Date(1576479600000)
+    const today = new Date()
     const isItTimeToCommit = SmashLeague.isItTimeToCommitInProgress(today, Ranking.current_week)
     
     let now = today

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,6 @@ async function Main() {
 
     // Next milisecond after last update because it's inclusive search
     const lastInProgressUpdated = new Date(Ranking.in_progress.last_update_ts + 1)
-    
     const opts = { latest: now, oldest: lastInProgressUpdated }
     const slackResponse = await Slack.getMessagesFromPrivateChannel(SMASH_SLACK_CHANNEL_ID, opts)
     const activities = await SmashLeagueInteractions.categorizeSlackMessages(


### PR DESCRIPTION
## What does this do?
* Fixes a bug were the inactive  players that have been already deleted will appear forever in the ranking README
* Players will keep being punished after 1 week of inactivity but will only get deleted from scoreboard after 2 weeks if the reach points lower than an unranked player.

## How can this change be undone in case of failure?

1. Notify the administrators
2. Request a revert of the PR


ping @Xotl
